### PR TITLE
Remove port visitors

### DIFF
--- a/examples/gpb.rs
+++ b/examples/gpb.rs
@@ -163,7 +163,7 @@ struct GPB<'a> {
 }
 
 impl xdevs::Coupled for GPB<'_> {
-    fn ic(from: &Self::ComponentsOutput<'_>, to: &mut Self::ComponentsInput<'_>) {
+    fn ic(from: &Self::ComponentsOutput, to: &mut Self::ComponentsInput) {
         from.generator
             .out_job
             .couple(&mut to.buffer.in_item)

--- a/examples/gpt.rs
+++ b/examples/gpt.rs
@@ -164,7 +164,7 @@ struct GPT {
 }
 
 impl xdevs::Coupled for GPT {
-    fn ic(from: &Self::ComponentsOutput<'_>, to: &mut Self::ComponentsInput<'_>) {
+    fn ic(from: &Self::ComponentsOutput, to: &mut Self::ComponentsInput) {
         from.generator
             .out_job
             .couple(&mut to.processor.in_job)
@@ -196,7 +196,7 @@ struct EF {
 }
 
 impl xdevs::Coupled for EF {
-    fn ic(from: &Self::ComponentsOutput<'_>, to: &mut Self::ComponentsInput<'_>) {
+    fn ic(from: &Self::ComponentsOutput, to: &mut Self::ComponentsInput) {
         from.generator
             .out_job
             .couple(&mut to.transducer.in_generator)
@@ -206,12 +206,12 @@ impl xdevs::Coupled for EF {
             .couple(&mut to.generator.in_stop)
             .unwrap();
     }
-    fn eic(from: &Self::Input, to: &mut Self::ComponentsInput<'_>) {
+    fn eic(from: &Self::Input, to: &mut Self::ComponentsInput) {
         from.in_processor
             .couple(&mut to.transducer.in_processor)
             .unwrap();
     }
-    fn eoc(from: &Self::ComponentsOutput<'_>, to: &mut Self::Output) {
+    fn eoc(from: &Self::ComponentsOutput, to: &mut Self::Output) {
         from.generator
             .out_job
             .couple(&mut to.out_generator)
@@ -227,7 +227,7 @@ struct EFP {
 }
 
 impl xdevs::Coupled for EFP {
-    fn ic(from: &Self::ComponentsOutput<'_>, to: &mut Self::ComponentsInput<'_>) {
+    fn ic(from: &Self::ComponentsOutput, to: &mut Self::ComponentsInput) {
         from.ef
             .out_generator
             .couple(&mut to.processor.in_job)

--- a/examples/gpt_async.rs
+++ b/examples/gpt_async.rs
@@ -166,7 +166,7 @@ struct GPT {
 }
 
 impl xdevs::Coupled for GPT {
-    fn ic(from: &Self::ComponentsOutput<'_>, to: &mut Self::ComponentsInput<'_>) {
+    fn ic(from: &Self::ComponentsOutput, to: &mut Self::ComponentsInput) {
         from.generator
             .out_job
             .couple(&mut to.processor.in_job)
@@ -198,7 +198,7 @@ struct EF {
 }
 
 impl xdevs::Coupled for EF {
-    fn ic(from: &Self::ComponentsOutput<'_>, to: &mut Self::ComponentsInput<'_>) {
+    fn ic(from: &Self::ComponentsOutput, to: &mut Self::ComponentsInput) {
         from.generator
             .out_job
             .couple(&mut to.transducer.in_generator)
@@ -208,12 +208,12 @@ impl xdevs::Coupled for EF {
             .couple(&mut to.generator.in_stop)
             .unwrap();
     }
-    fn eic(from: &Self::Input, to: &mut Self::ComponentsInput<'_>) {
+    fn eic(from: &Self::Input, to: &mut Self::ComponentsInput) {
         from.in_processor
             .couple(&mut to.transducer.in_processor)
             .unwrap();
     }
-    fn eoc(from: &Self::ComponentsOutput<'_>, to: &mut Self::Output) {
+    fn eoc(from: &Self::ComponentsOutput, to: &mut Self::Output) {
         from.generator
             .out_job
             .couple(&mut to.out_generator)
@@ -229,7 +229,7 @@ struct EFP {
 }
 
 impl xdevs::Coupled for EFP {
-    fn ic(from: &Self::ComponentsOutput<'_>, to: &mut Self::ComponentsInput<'_>) {
+    fn ic(from: &Self::ComponentsOutput, to: &mut Self::ComponentsInput) {
         from.ef
             .out_generator
             .couple(&mut to.processor.in_job)

--- a/examples/multiprocessor.rs
+++ b/examples/multiprocessor.rs
@@ -207,10 +207,10 @@ struct MultiProcessor {
 }
 
 impl xdevs::Coupled for MultiProcessor {
-    fn eic(_from: &Self::Input, _to: &mut Self::ComponentsInput<'_>) {
+    fn eic(_from: &Self::Input, _to: &mut Self::ComponentsInput) {
         // No external input coupling needed, this implementation could be omitted
     }
-    fn ic(from: &Self::ComponentsOutput<'_>, to: &mut Self::ComponentsInput<'_>) {
+    fn ic(from: &Self::ComponentsOutput, to: &mut Self::ComponentsInput) {
         from.generator
             .out_job
             .couple(&mut to.load_balancer.in_job)
@@ -227,7 +227,7 @@ impl xdevs::Coupled for MultiProcessor {
             proc_port.couple(&mut to.collector.in_jobs).unwrap();
         }
     }
-    fn eoc(_from: &Self::ComponentsOutput<'_>, _to: &mut Self::Output) {
+    fn eoc(_from: &Self::ComponentsOutput, _to: &mut Self::Output) {
         // No external output coupling needed, this implementation could be omitted
     }
 }

--- a/macros/src/component.rs
+++ b/macros/src/component.rs
@@ -258,8 +258,6 @@ fn impl_component(
         unsafe impl #impl_generics xdevs::traits::Component for #ident #ty_generics{
             type Input = #input_ident #input_generics;
             type Output = #output_ident #output_generics;
-            type InputRef<'__xdevs_ports> = &'__xdevs_ports mut #input_ident #input_generics where Self: '__xdevs_ports;
-            type OutputRef<'__xdevs_ports> = &'__xdevs_ports #output_ident #output_generics where Self: '__xdevs_ports;
             #[inline]
             fn get_t_last(&self) -> f64 {
                 self.t_last
@@ -275,30 +273,6 @@ fn impl_component(
             #[inline]
             fn set_t_next(&mut self, t_next: f64) {
                 self.t_next = t_next;
-            }
-            #[inline]
-            fn get_input(&self) -> &Self::Input {
-                &self.input
-            }
-            #[inline]
-            fn get_input_mut(&mut self) -> &mut Self::Input {
-                &mut self.input
-            }
-            #[inline]
-            fn get_output(&self) -> &Self::Output {
-                &self.output
-            }
-            #[inline]
-            fn get_output_mut(&mut self) -> &mut Self::Output {
-                &mut self.output
-            }
-            #[inline]
-            fn get_ports(&mut self) -> (Self::InputRef<'_>, Self::OutputRef<'_>) {
-                (&mut self.input, &self.output)
-            }
-            #[inline]
-            fn get_out_ports(&self) -> Self::OutputRef<'_> {
-                &self.output
             }
         }
     }

--- a/macros/src/component/atomic.rs
+++ b/macros/src/component/atomic.rs
@@ -153,14 +153,12 @@ impl Component {
                             let e = t - ::xdevs::traits::Component::get_t_last(self);
                             <Self as ::xdevs::Atomic>::delta_ext(&mut self.state, e, input);
                         }
-                        // clear input events
                     } else if t >= t_next {
                         // internal transition
                         <Self as ::xdevs::Atomic>::delta_int(&mut self.state);
                     } else {
                         return t_next; // nothing to do
                     }
-                    // clear output events
                     // get t_next from ta and set new t_last and t_next
                     t_next = t + <Self as ::xdevs::Atomic>::ta(&self.state);
                     ::xdevs::traits::Component::set_t_last(self, t);

--- a/macros/src/component/atomic.rs
+++ b/macros/src/component/atomic.rs
@@ -142,20 +142,26 @@ impl Component {
                     }
                 }
                 #[inline]
-                fn delta(&mut self, input: &Self::Input, t: f64) -> f64 {
+                fn delta(&mut self, input: &mut Self::Input, output: &mut Self::Output, t: f64) -> f64 {
                     let mut t_next = ::xdevs::traits::Component::get_t_next(self);
                     if !::xdevs::traits::Bag::is_empty(input) {
                         if t >= t_next {
                             // confluent transition
                             <Self as ::xdevs::Atomic>::delta_conf(&mut self.state, input);
+                            // clear output events
+                            <Self::Output as ::xdevs::traits::Bag>::clear(output);
                         } else {
                             // external transition
                             let e = t - ::xdevs::traits::Component::get_t_last(self);
                             <Self as ::xdevs::Atomic>::delta_ext(&mut self.state, e, input);
                         }
+                        // clear input events
+                        <Self::Input as ::xdevs::traits::Bag>::clear(input);
                     } else if t >= t_next {
                         // internal transition
                         <Self as ::xdevs::Atomic>::delta_int(&mut self.state);
+                        // clear output events
+                        <Self::Output as ::xdevs::traits::Bag>::clear(output);
                     } else {
                         return t_next; // nothing to do
                     }

--- a/macros/src/component/atomic.rs
+++ b/macros/src/component/atomic.rs
@@ -96,8 +96,6 @@ impl Component {
             #state_struct
             #rt_engine_impl
             pub struct #ident #impl_generics #where_clause {
-                pub input: #input_ident #input_generics,
-                pub output: #output_ident #output_generics,
                 pub t_last: f64,
                 pub t_next: f64,
                 pub state: #state_ident #state_generics,
@@ -106,8 +104,6 @@ impl Component {
                 #[inline]
                 pub const fn build(#(#state_fields: #state_tys),*) -> Self {
                     Self {
-                        input: #input_ident::new(),
-                        output: #output_ident::new(),
                         t_last: 0.0,
                         t_next: f64::INFINITY,
                         state: #state_ident::new(#(#state_fields),*),
@@ -139,26 +135,25 @@ impl Component {
                     ::xdevs::traits::Component::set_t_next(self, f64::INFINITY);
                 }
                 #[inline]
-                fn lambda(&mut self, t: f64) {
+                fn lambda(&mut self, output: &mut Self::Output, t: f64) {
                     if t >= ::xdevs::traits::Component::get_t_next(self) {
                         // execute atomic model's lambda if applies
-                        <Self as ::xdevs::Atomic>::lambda(&self.state, &mut self.output);
+                        <Self as ::xdevs::Atomic>::lambda(&self.state, output);
                     }
                 }
                 #[inline]
-                fn delta(&mut self, t: f64) -> f64 {
+                fn delta(&mut self, input: &Self::Input, t: f64) -> f64 {
                     let mut t_next = ::xdevs::traits::Component::get_t_next(self);
-                    if !::xdevs::traits::Bag::is_empty(&self.input) {
+                    if !::xdevs::traits::Bag::is_empty(input) {
                         if t >= t_next {
                             // confluent transition
-                            <Self as ::xdevs::Atomic>::delta_conf(&mut self.state, &self.input);
+                            <Self as ::xdevs::Atomic>::delta_conf(&mut self.state, input);
                         } else {
                             // external transition
                             let e = t - ::xdevs::traits::Component::get_t_last(self);
-                            <Self as ::xdevs::Atomic>::delta_ext(&mut self.state, e, &self.input);
+                            <Self as ::xdevs::Atomic>::delta_ext(&mut self.state, e, input);
                         }
                         // clear input events
-                        ::xdevs::traits::Component::clear_input(self);
                     } else if t >= t_next {
                         // internal transition
                         <Self as ::xdevs::Atomic>::delta_int(&mut self.state);
@@ -166,7 +161,6 @@ impl Component {
                         return t_next; // nothing to do
                     }
                     // clear output events
-                    ::xdevs::traits::Component::clear_output(self);
                     // get t_next from ta and set new t_last and t_next
                     t_next = t + <Self as ::xdevs::Atomic>::ta(&self.state);
                     ::xdevs::traits::Component::set_t_last(self, t);

--- a/macros/src/component/coupled.rs
+++ b/macros/src/component/coupled.rs
@@ -105,11 +105,11 @@ impl Component {
         // Generate wrapper structs for inner components' inputs and outputs
         // These structs hold all inner components' inputs/outputs,
         // allowing them to be passed as a single argument to trait methods.
-        let component_inputs_ident = Ident::new(&format!("{}ComponentsInput", ident), ident.span());
-        let component_outputs_ident =
+        let components_input_ident = Ident::new(&format!("{}ComponentsInput", ident), ident.span());
+        let components_output_ident =
             Ident::new(&format!("{}ComponentsOutput", ident), ident.span());
 
-        let component_input_fields: Vec<TokenStream2> = self
+        let components_input_fields: Vec<TokenStream2> = self
             .components
             .components
             .iter()
@@ -122,7 +122,7 @@ impl Component {
             })
             .collect();
 
-        let component_output_fields: Vec<TokenStream2> = self
+        let components_output_fields: Vec<TokenStream2> = self
             .components
             .components
             .iter()
@@ -146,19 +146,19 @@ impl Component {
 
             /// Wrapper struct holding mutable references to all inner components' inputs.
             #[derive(::xdevs::Bag)]
-            pub struct #component_inputs_ident #components_impl_generics #components_where_clause {
-                #(#component_input_fields),*
+            pub struct #components_input_ident #components_impl_generics #components_where_clause {
+                #(#components_input_fields),*
             }
 
             /// Wrapper struct holding references to all inner components' outputs.
             #[derive(::xdevs::Bag)]
-            pub struct #component_outputs_ident #components_impl_generics #components_where_clause {
-                #(#component_output_fields),*
+            pub struct #components_output_ident #components_impl_generics #components_where_clause {
+                #(#components_output_fields),*
             }
 
             pub struct #ident #impl_generics #where_clause {
-                pub components_input: #component_inputs_ident #components_ty_generics,
-                pub components_output: #component_outputs_ident #components_ty_generics,
+                pub components_input: #components_input_ident #components_ty_generics,
+                pub components_output: #components_output_ident #components_ty_generics,
                 pub t_last: f64,
                 pub t_next: f64,
                 pub components: #components_ident #components_ty_generics,
@@ -167,8 +167,8 @@ impl Component {
                 #[inline]
                 pub fn build(#(#components_fields: #components_tys),*) -> Self {
                     Self {
-                        components_input: <#component_inputs_ident #components_ty_generics as ::xdevs::traits::Bag>::build(),
-                        components_output: <#component_outputs_ident #components_ty_generics as ::xdevs::traits::Bag>::build(),
+                        components_input: <#components_input_ident #components_ty_generics as ::xdevs::traits::Bag>::build(),
+                        components_output: <#components_output_ident #components_ty_generics as ::xdevs::traits::Bag>::build(),
                         t_last: 0.0,
                         t_next: f64::INFINITY,
                         components: #components_ident::new(#(#components_fields),*),
@@ -177,8 +177,8 @@ impl Component {
             }
             #component_impl
             unsafe impl #impl_generics ::xdevs::traits::PartialCoupled for #ident #ty_generics #where_clause {
-                type ComponentsInput = #component_inputs_ident #components_ty_generics;
-                type ComponentsOutput = #component_outputs_ident #components_ty_generics;
+                type ComponentsInput = #components_input_ident #components_ty_generics;
+                type ComponentsOutput = #components_output_ident #components_ty_generics;
             }
             unsafe impl #impl_generics ::xdevs::traits::AbstractSimulator for #ident #ty_generics #where_clause {
                 #[inline]

--- a/macros/src/component/coupled.rs
+++ b/macros/src/component/coupled.rs
@@ -6,7 +6,7 @@ use super::CommonComponent;
 use super::ParsedComponentFields;
 use components::Components;
 use proc_macro2::TokenStream as TokenStream2;
-use syn::{parse2, Error, GenericParam, Ident, ItemStruct, Result};
+use syn::{parse2, Error, Ident, ItemStruct, Result};
 
 /// Parsed representation of a coupled2 component macro input.
 pub struct Component {
@@ -79,9 +79,10 @@ impl Component {
 
         // Extract generics for impl
         let (impl_generics, ty_generics, where_clause) = self.common.generics.split_for_impl();
-        let (_, input_generics, _) = &self.common.input.generics.split_for_impl();
-        let (_, output_generics, _) = &self.common.output.generics.split_for_impl();
-        let (_, components_generics, _) = &self.components.generics.split_for_impl();
+        let (_, input_ty_generics, _) = &self.common.input.generics.split_for_impl();
+        let (_, output_ty_generics, _) = &self.common.output.generics.split_for_impl();
+        let (components_impl_generics, components_ty_generics, components_where_clause) =
+            &self.components.generics.split_for_impl();
 
         // Generate input, output, and components structs
         let is_bagmux = self.common.rt_engine.is_some();
@@ -94,17 +95,16 @@ impl Component {
             &input_ident,
             &output_ident,
             &self.common.generics,
-            input_generics,
-            output_generics,
+            input_ty_generics,
+            output_ty_generics,
         );
 
         // Generate rt_engine code if defined
         let rt_engine_impl = self.common.quote_rt_engine();
 
         // Generate wrapper structs for inner components' inputs and outputs
-        // These structs hold references to all inner components' inputs/outputs,
-        // allowing them to be passed as a single argument to trait methods without
-        // exposing the component's state or internal structure.
+        // These structs hold all inner components' inputs/outputs,
+        // allowing them to be passed as a single argument to trait methods.
         let component_inputs_ident = Ident::new(&format!("{}ComponentsInput", ident), ident.span());
         let component_outputs_ident =
             Ident::new(&format!("{}ComponentsOutput", ident), ident.span());
@@ -117,7 +117,7 @@ impl Component {
                 let field_ident = &field.ident;
                 let field_ty = &field.ty;
                 quote::quote! {
-                    pub #field_ident: <#field_ty as ::xdevs::traits::Component>::InputRef<'__xdevs_inner>
+                    pub #field_ident: <#field_ty as ::xdevs::traits::Component>::Input
                 }
             })
             .collect();
@@ -130,128 +130,12 @@ impl Component {
                 let field_ident = &field.ident;
                 let field_ty = &field.ty;
                 quote::quote! {
-                    pub #field_ident: <#field_ty as ::xdevs::traits::Component>::OutputRef<'__xdevs_inner>
-                }
-            })
-            .collect();
-
-        let component_ports_inits: Vec<TokenStream2> = self
-            .components
-            .components
-            .iter()
-            .map(|field| {
-                let field_ident = &field.ident;
-                let input_var = quote::format_ident!("{}_input", field_ident);
-                let output_var = quote::format_ident!("{}_output", field_ident);
-                quote::quote! {
-                    let (#input_var, #output_var) = ::xdevs::traits::Component::get_ports(&mut self.components.#field_ident);
-                }
-            })
-            .collect();
-
-        // For lambda, we only use output refs via get_out_ports
-        let component_out_ports_inits: Vec<TokenStream2> = self
-            .components
-            .components
-            .iter()
-            .map(|field| {
-                let field_ident = &field.ident;
-                let output_var = quote::format_ident!("{}_output", field_ident);
-                quote::quote! {
-                    let #output_var = ::xdevs::traits::Component::get_out_ports(&self.components.#field_ident);
-                }
-            })
-            .collect();
-
-        let component_input_inits: Vec<TokenStream2> = self
-            .components
-            .components
-            .iter()
-            .map(|field| {
-                let field_ident = &field.ident;
-                let input_var = quote::format_ident!("{}_input", field_ident);
-                quote::quote! {
-                    #field_ident: #input_var
-                }
-            })
-            .collect();
-
-        let component_output_inits: Vec<TokenStream2> = self
-            .components
-            .components
-            .iter()
-            .map(|field| {
-                let field_ident = &field.ident;
-                let output_var = quote::format_ident!("{}_output", field_ident);
-                quote::quote! {
-                    #field_ident: #output_var
+                    pub #field_ident: <#field_ty as ::xdevs::traits::Component>::Output
                 }
             })
             .collect();
 
         // Generate struct definition generics and usage generics for ComponentsInput/ComponentsOutput
-        // We need to include ALL generic parameters from components (lifetimes, types, consts)
-        // so that the field types can reference them.
-        let components_params: Vec<_> = self.components.generics.params.iter().collect();
-        let components_ty_args: Vec<TokenStream2> = self
-            .components
-            .generics
-            .params
-            .iter()
-            .map(|p| match p {
-                GenericParam::Type(tp) => {
-                    let ident = &tp.ident;
-                    quote::quote! { #ident }
-                }
-                GenericParam::Lifetime(lp) => {
-                    let lifetime = &lp.lifetime;
-                    quote::quote! { #lifetime }
-                }
-                GenericParam::Const(cp) => {
-                    let ident = &cp.ident;
-                    quote::quote! { #ident }
-                }
-            })
-            .collect();
-        let has_components_params = !components_params.is_empty();
-
-        // Extract lifetime parameters to generate bounds (lifetime: '__xdevs_inner)
-        let lifetime_params: Vec<_> = self
-            .components
-            .generics
-            .params
-            .iter()
-            .filter_map(|p| {
-                if let GenericParam::Lifetime(lp) = p {
-                    Some(&lp.lifetime)
-                } else {
-                    None
-                }
-            })
-            .collect();
-        let has_lifetime_params = !lifetime_params.is_empty();
-
-        // Generate where clause for wrapper structs to bound component lifetimes
-        let wrapper_where_clause = if has_lifetime_params {
-            quote::quote! { where #(#lifetime_params: '__xdevs_inner),* }
-        } else {
-            quote::quote! {}
-        };
-
-        let (wrapper_def_generics, wrapper_use_generics, wrapper_trait_generics) =
-            if has_components_params {
-                (
-                    quote::quote! { <'__xdevs_inner, #(#components_params),*> },
-                    quote::quote! { <'_, #(#components_ty_args),*> },
-                    quote::quote! { <'__xdevs_inner, #(#components_ty_args),*> },
-                )
-            } else {
-                (
-                    quote::quote! { <'__xdevs_inner> },
-                    quote::quote! { <'_> },
-                    quote::quote! { <'__xdevs_inner> },
-                )
-            };
 
         // Generate the expanded code
         let expanded = quote::quote! {
@@ -261,28 +145,30 @@ impl Component {
             #rt_engine_impl
 
             /// Wrapper struct holding mutable references to all inner components' inputs.
-            pub struct #component_inputs_ident #wrapper_def_generics #wrapper_where_clause {
+            #[derive(::xdevs::Bag)]
+            pub struct #component_inputs_ident #components_impl_generics #components_where_clause {
                 #(#component_input_fields),*
             }
 
             /// Wrapper struct holding references to all inner components' outputs.
-            pub struct #component_outputs_ident #wrapper_def_generics #wrapper_where_clause {
+            #[derive(::xdevs::Bag)]
+            pub struct #component_outputs_ident #components_impl_generics #components_where_clause {
                 #(#component_output_fields),*
             }
 
             pub struct #ident #impl_generics #where_clause {
-                pub input: #input_ident #input_generics,
-                pub output: #output_ident #output_generics,
+                pub components_input: #component_inputs_ident #components_ty_generics,
+                pub components_output: #component_outputs_ident #components_ty_generics,
                 pub t_last: f64,
                 pub t_next: f64,
-                pub components: #components_ident #components_generics,
+                pub components: #components_ident #components_ty_generics,
             }
             impl #impl_generics #ident #ty_generics #where_clause {
                 #[inline]
-                pub const fn build(#(#components_fields: #components_tys),*) -> Self {
+                pub fn build(#(#components_fields: #components_tys),*) -> Self {
                     Self {
-                        input: #input_ident::new(),
-                        output: #output_ident::new(),
+                        components_input: <#component_inputs_ident #components_ty_generics as ::xdevs::traits::Bag>::build(),
+                        components_output: <#component_outputs_ident #components_ty_generics as ::xdevs::traits::Bag>::build(),
                         t_last: 0.0,
                         t_next: f64::INFINITY,
                         components: #components_ident::new(#(#components_fields),*),
@@ -291,8 +177,8 @@ impl Component {
             }
             #component_impl
             unsafe impl #impl_generics ::xdevs::traits::PartialCoupled for #ident #ty_generics #where_clause {
-                type ComponentsInput = #component_inputs_ident #wrapper_trait_generics;
-                type ComponentsOutput = #component_outputs_ident #wrapper_trait_generics;
+                type ComponentsInput = #component_inputs_ident #components_ty_generics;
+                type ComponentsOutput = #component_outputs_ident #components_ty_generics;
             }
             unsafe impl #impl_generics ::xdevs::traits::AbstractSimulator for #ident #ty_generics #where_clause {
                 #[inline]
@@ -318,42 +204,32 @@ impl Component {
                 }
 
                 #[inline]
-                fn lambda(&mut self, t: f64) {
+                fn lambda(&mut self, output: &mut Self::Output, t: f64) {
                     if t >= ::xdevs::traits::Component::get_t_next(self) {
                         // propagate lambda to all components
-                        #(::xdevs::traits::AbstractSimulator::lambda(&mut self.components.#components_fields, t);)*
+                        #(::xdevs::traits::AbstractSimulator::lambda(&mut self.components.#components_fields, &mut self.components_output.#components_fields, t);)*
                         // propagate EOCs via Coupled trait
-                        #(#component_out_ports_inits)*
-                        let component_outputs: #component_outputs_ident #wrapper_use_generics = #component_outputs_ident {
-                            #(#component_output_inits),*
-                        };
-                        <Self as ::xdevs::Coupled>::eoc(&component_outputs, &mut self.output);
+                        <Self as ::xdevs::Coupled>::eoc(&self.components_output, output);
                     }
                 }
 
                 #[inline]
-                fn delta(&mut self, t: f64) -> f64 {
+                fn delta(&mut self, input: &Self::Input, t: f64) -> f64 {
                     // propagate EICs and ICs via Coupled trait
-                    {
-                        #(#component_ports_inits)*
-                        let component_outputs: #component_outputs_ident #wrapper_use_generics = #component_outputs_ident {
-                            #(#component_output_inits),*
-                        };
-                        let mut component_inputs: #component_inputs_ident #wrapper_use_generics = #component_inputs_ident {
-                            #(#component_input_inits),*
-                        };
-                        <Self as ::xdevs::Coupled>::eic(&self.input, &mut component_inputs);
-                        <Self as ::xdevs::Coupled>::ic(&component_outputs, &mut component_inputs);
-                    }
+                    <Self as ::xdevs::Coupled>::eic(input, &mut self.components_input);
+                    <Self as ::xdevs::Coupled>::ic(&self.components_output, &mut self.components_input);
+
                     // get minimum t_next from all components after executing their delta
                     let mut t_next = f64::INFINITY;
-                    #(t_next = f64::min(t_next, ::xdevs::traits::AbstractSimulator::delta(&mut self.components.#components_fields, t));)*
-                    // clear input and output events
-                    ::xdevs::traits::Component::clear_output(self);
-                    ::xdevs::traits::Component::clear_input(self);
+                    #(t_next = f64::min(t_next, ::xdevs::traits::AbstractSimulator::delta(&mut self.components.#components_fields, &self.components_input.#components_fields, t));)*
+
                     // set t_last to t and t_next to minimum t_next
                     ::xdevs::traits::Component::set_t_last(self, t);
                     ::xdevs::traits::Component::set_t_next(self, t_next);
+
+                    // clear input and output events for all components
+                    <<Self as ::xdevs::traits::PartialCoupled>::ComponentsInput as ::xdevs::traits::Bag>::clear(&mut self.components_input);
+                    <<Self as ::xdevs::traits::PartialCoupled>::ComponentsOutput as ::xdevs::traits::Bag>::clear(&mut self.components_output);
 
                     t_next
                 }

--- a/macros/src/component/coupled.rs
+++ b/macros/src/component/coupled.rs
@@ -291,8 +291,8 @@ impl Component {
             }
             #component_impl
             unsafe impl #impl_generics ::xdevs::traits::PartialCoupled for #ident #ty_generics #where_clause {
-                type ComponentsInput<'__xdevs_inner> = #component_inputs_ident #wrapper_trait_generics where Self: '__xdevs_inner;
-                type ComponentsOutput<'__xdevs_inner> = #component_outputs_ident #wrapper_trait_generics where Self: '__xdevs_inner;
+                type ComponentsInput = #component_inputs_ident #wrapper_trait_generics;
+                type ComponentsOutput = #component_outputs_ident #wrapper_trait_generics;
             }
             unsafe impl #impl_generics ::xdevs::traits::AbstractSimulator for #ident #ty_generics #where_clause {
                 #[inline]

--- a/macros/src/component/coupled.rs
+++ b/macros/src/component/coupled.rs
@@ -214,22 +214,26 @@ impl Component {
                 }
 
                 #[inline]
-                fn delta(&mut self, input: &Self::Input, t: f64) -> f64 {
+                fn delta(&mut self, input: &mut Self::Input, output: &mut Self::Output, t: f64) -> f64 {
                     // propagate EICs and ICs via Coupled trait
                     <Self as ::xdevs::Coupled>::eic(input, &mut self.components_input);
                     <Self as ::xdevs::Coupled>::ic(&self.components_output, &mut self.components_input);
 
                     // get minimum t_next from all components after executing their delta
                     let mut t_next = f64::INFINITY;
-                    #(t_next = f64::min(t_next, ::xdevs::traits::AbstractSimulator::delta(&mut self.components.#components_fields, &self.components_input.#components_fields, t));)*
+                    #(t_next = f64::min(t_next, ::xdevs::traits::AbstractSimulator::delta(
+                        &mut self.components.#components_fields,
+                        &mut self.components_input.#components_fields,
+                        &mut self.components_output.#components_fields,
+                         t));)*
 
                     // set t_last to t and t_next to minimum t_next
                     ::xdevs::traits::Component::set_t_last(self, t);
                     ::xdevs::traits::Component::set_t_next(self, t_next);
 
-                    // clear input and output events for all components
-                    <<Self as ::xdevs::traits::PartialCoupled>::ComponentsInput as ::xdevs::traits::Bag>::clear(&mut self.components_input);
-                    <<Self as ::xdevs::traits::PartialCoupled>::ComponentsOutput as ::xdevs::traits::Bag>::clear(&mut self.components_output);
+                    // clear input and output events
+                    <Self::Input as ::xdevs::traits::Bag>::clear(input);
+                    <Self::Output as ::xdevs::traits::Bag>::clear(output);
 
                     t_next
                 }

--- a/macros/src/component/port.rs
+++ b/macros/src/component/port.rs
@@ -55,7 +55,7 @@ impl Ports {
         };
 
         quote::quote! {
-            #[derive(Debug, Default, ::xdevs::Bag #bagmux)]
+            #[derive(::xdevs::Bag #bagmux)]
             pub struct #ident #impl_generics #where_clause {
                 #(pub #ports_ident: #ports_ty,)*
             }

--- a/macros/src/component/state.rs
+++ b/macros/src/component/state.rs
@@ -34,7 +34,6 @@ impl State {
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
 
         quote::quote! {
-            #[derive(Debug)]
             pub struct #ident #impl_generics #where_clause {
                 #(#fields_ident: #fields_ty,)*
             }

--- a/macros/src/derive.rs
+++ b/macros/src/derive.rs
@@ -42,7 +42,8 @@ pub fn derive_bag(input: DeriveInput) -> Result<TokenStream2> {
         Fields::Named(fields) => {
             let build_fields = fields.named.iter().map(|field| {
                 let field_ident = field.ident.as_ref().expect("named field must have ident");
-                quote::quote!(#field_ident: <_ as ::xdevs::traits::Bag>::build())
+                let field_ty = &field.ty;
+                quote::quote!(#field_ident: <#field_ty as ::xdevs::traits::Bag>::build())
             });
             quote::quote! {
                 Self {
@@ -51,10 +52,10 @@ pub fn derive_bag(input: DeriveInput) -> Result<TokenStream2> {
             }
         }
         Fields::Unnamed(fields) => {
-            let build_elems = fields
-                .unnamed
-                .iter()
-                .map(|_| quote::quote!(<_ as ::xdevs::traits::Bag>::build()));
+            let build_elems = fields.unnamed.iter().map(|field| {
+                let field_ty = &field.ty;
+                quote::quote!(<#field_ty as ::xdevs::traits::Bag>::build())
+            });
             quote::quote! {
                 Self(
                     #(#build_elems),*

--- a/macros/src/derive.rs
+++ b/macros/src/derive.rs
@@ -38,6 +38,32 @@ pub fn derive_bag(input: DeriveInput) -> Result<TokenStream2> {
         Fields::Unit => Vec::new(),
     };
 
+    let build_body = match &fields {
+        Fields::Named(fields) => {
+            let build_fields = fields.named.iter().map(|field| {
+                let field_ident = field.ident.as_ref().expect("named field must have ident");
+                quote::quote!(#field_ident: <_ as ::xdevs::traits::Bag>::build())
+            });
+            quote::quote! {
+                Self {
+                    #(#build_fields),*
+                }
+            }
+        }
+        Fields::Unnamed(fields) => {
+            let build_elems = fields
+                .unnamed
+                .iter()
+                .map(|_| quote::quote!(<_ as ::xdevs::traits::Bag>::build()));
+            quote::quote! {
+                Self(
+                    #(#build_elems),*
+                )
+            }
+        }
+        Fields::Unit => quote::quote! { Self },
+    };
+
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let is_empty_body = if accesses.is_empty() {
@@ -52,6 +78,11 @@ pub fn derive_bag(input: DeriveInput) -> Result<TokenStream2> {
 
     Ok(quote::quote! {
         unsafe impl #impl_generics ::xdevs::traits::Bag for #ident #ty_generics #where_clause {
+            #[inline]
+            fn build() -> Self {
+                #build_body
+            }
+
             #[inline]
             fn is_empty(&self) -> bool {
                 #is_empty_body

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -30,8 +30,8 @@ impl<T: AsPort, const N: usize> AsPort for [T; N] {
 impl<T: AsPort, const N: usize> Sealed for [T; N] {}
 
 unsafe impl<T: Component, const N: usize> Component for [T; N] {
-    type Input = ();
-    type Output = ();
+    type Input = [T::Input; N];
+    type Output = [T::Output; N];
 
     fn get_t_last(&self) -> f64 {
         self.iter()
@@ -68,14 +68,19 @@ unsafe impl<T: AbstractSimulator, const N: usize> AbstractSimulator for [T; N] {
     }
 
     #[inline]
-    fn lambda(&mut self, t: f64) {
-        self.iter_mut().for_each(|c| c.lambda(t));
+    fn lambda(&mut self, output: &mut Self::Output, t: f64) {
+        self.iter_mut()
+            .zip(output.iter_mut())
+            .for_each(|(c, out)| c.lambda(out, t));
     }
 
     #[inline]
-    fn delta(&mut self, t: f64) -> f64 {
+    fn delta(&mut self, input: &Self::Input, t: f64) -> f64 {
         self.iter_mut()
-            .fold(f64::INFINITY, |t_next, c| f64::min(t_next, c.delta(t)))
+            .zip(input.iter())
+            .fold(f64::INFINITY, |t_next, (c, inp)| {
+                f64::min(t_next, c.delta(inp, t))
+            })
     }
 }
 
@@ -127,12 +132,12 @@ macro_rules! impl_ref {
                 (**self).stop(t_stop);
             }
 
-            fn lambda(&mut self, t: f64) {
-                (**self).lambda(t);
+            fn lambda(&mut self, output: &mut Self::Output, t: f64) {
+                (**self).lambda(output, t);
             }
 
-            fn delta(&mut self, t: f64) -> f64 {
-                (**self).delta(t)
+            fn delta(&mut self, input: &Self::Input, t: f64) -> f64 {
+                (**self).delta(input, t)
             }
         }
     };

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -10,6 +10,10 @@ use crate::traits::Component;
 
 //////////////////////////////////////////////// Arrays //////////////////////////////////////////////
 unsafe impl<T: Bag, const N: usize> Bag for [T; N] {
+    fn build() -> Self {
+        core::array::from_fn(|_| T::build())
+    }
+
     fn is_empty(&self) -> bool {
         self.iter().all(|bag| bag.is_empty())
     }
@@ -80,6 +84,10 @@ unsafe impl<T: AbstractSimulator, const N: usize> AbstractSimulator for [T; N] {
 macro_rules! impl_ref {
     ( $ty:ty ) => {
         unsafe impl<T: Bag> Bag for $ty {
+            fn build() -> Self {
+                unimplemented!("Cannot build a reference bag. This method should never be called.")
+            }
+
             fn is_empty(&self) -> bool {
                 (**self).is_empty()
             }
@@ -137,6 +145,9 @@ impl_ref!(alloc::boxed::Box<T>);
 
 //////////////////////////////////////////////// Empty Tuple //////////////////////////////////////////////
 unsafe impl Bag for () {
+    fn build() -> Self {
+        ()
+    }
     fn is_empty(&self) -> bool {
         true
     }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -75,11 +75,12 @@ unsafe impl<T: AbstractSimulator, const N: usize> AbstractSimulator for [T; N] {
     }
 
     #[inline]
-    fn delta(&mut self, input: &Self::Input, t: f64) -> f64 {
+    fn delta(&mut self, input: &mut Self::Input, output: &mut Self::Output, t: f64) -> f64 {
         self.iter_mut()
-            .zip(input.iter())
-            .fold(f64::INFINITY, |t_next, (c, inp)| {
-                f64::min(t_next, c.delta(inp, t))
+            .zip(input.iter_mut())
+            .zip(output.iter_mut())
+            .fold(f64::INFINITY, |t_next, ((c, inp), out)| {
+                f64::min(t_next, c.delta(inp, out, t))
             })
     }
 }
@@ -88,20 +89,6 @@ unsafe impl<T: AbstractSimulator, const N: usize> AbstractSimulator for [T; N] {
 
 macro_rules! impl_ref {
     ( $ty:ty ) => {
-        unsafe impl<T: Bag> Bag for $ty {
-            fn build() -> Self {
-                unreachable!("Cannot build a reference bag. This method should never be called.")
-            }
-
-            fn is_empty(&self) -> bool {
-                (**self).is_empty()
-            }
-
-            fn clear(&mut self) {
-                (**self).clear();
-            }
-        }
-
         unsafe impl<T: Component> Component for $ty {
             type Input = T::Input;
             type Output = T::Output;
@@ -136,8 +123,8 @@ macro_rules! impl_ref {
                 (**self).lambda(output, t);
             }
 
-            fn delta(&mut self, input: &Self::Input, t: f64) -> f64 {
-                (**self).delta(input, t)
+            fn delta(&mut self, input: &mut Self::Input, output: &mut Self::Output, t: f64) -> f64 {
+                (**self).delta(input, output, t)
             }
         }
     };

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -28,14 +28,6 @@ impl<T: AsPort, const N: usize> Sealed for [T; N] {}
 unsafe impl<T: Component, const N: usize> Component for [T; N] {
     type Input = ();
     type Output = ();
-    type InputRef<'a>
-        = [T::InputRef<'a>; N]
-    where
-        Self: 'a;
-    type OutputRef<'a>
-        = [T::OutputRef<'a>; N]
-    where
-        Self: 'a;
 
     fn get_t_last(&self) -> f64 {
         self.iter()
@@ -55,65 +47,6 @@ unsafe impl<T: Component, const N: usize> Component for [T; N] {
 
     fn set_t_next(&mut self, t_next: f64) {
         self.iter_mut().for_each(|c| c.set_t_next(t_next));
-    }
-
-    fn get_input(&self) -> &Self::Input {
-        unimplemented!("get_input is not supported for collections; access elements directly")
-    }
-
-    fn get_input_mut(&mut self) -> &mut Self::Input {
-        unimplemented!("get_input_mut is not supported for collections; access elements directly")
-    }
-
-    fn get_output(&self) -> &Self::Output {
-        unimplemented!("get_output is not supported for collections; access elements directly")
-    }
-
-    fn get_output_mut(&mut self) -> &mut Self::Output {
-        unimplemented!("get_output_mut is not supported for collections; access elements directly")
-    }
-
-    fn get_ports(&mut self) -> (Self::InputRef<'_>, Self::OutputRef<'_>) {
-        // SAFETY: An uninitialized `[MaybeUninit<_>; N]` is valid.
-        let mut inputs: [core::mem::MaybeUninit<T::InputRef<'_>>; N] =
-            unsafe { core::mem::MaybeUninit::uninit().assume_init() };
-        let mut outputs: [core::mem::MaybeUninit<T::OutputRef<'_>>; N] =
-            unsafe { core::mem::MaybeUninit::uninit().assume_init() };
-
-        for (i, component) in self.iter_mut().enumerate() {
-            let (input, output) = component.get_ports();
-            inputs[i].write(input);
-            outputs[i].write(output);
-        }
-
-        // SAFETY: All elements have been initialized in the loop above.
-        unsafe {
-            (
-                inputs.map(|m| m.assume_init()),
-                outputs.map(|m| m.assume_init()),
-            )
-        }
-    }
-
-    fn get_out_ports(&self) -> Self::OutputRef<'_> {
-        // SAFETY: An uninitialized `[MaybeUninit<_>; N]` is valid.
-        let mut outputs: [core::mem::MaybeUninit<T::OutputRef<'_>>; N] =
-            unsafe { core::mem::MaybeUninit::uninit().assume_init() };
-
-        for (i, component) in self.iter().enumerate() {
-            outputs[i].write(component.get_out_ports());
-        }
-
-        // SAFETY: All elements have been initialized in the loop above.
-        unsafe { outputs.map(|m| m.assume_init()) }
-    }
-
-    fn clear_input(&mut self) {
-        self.iter_mut().for_each(|c| c.clear_input());
-    }
-
-    fn clear_output(&mut self) {
-        self.iter_mut().for_each(|c| c.clear_output());
     }
 }
 
@@ -159,14 +92,6 @@ macro_rules! impl_ref {
         unsafe impl<T: Component> Component for $ty {
             type Input = T::Input;
             type Output = T::Output;
-            type InputRef<'a>
-                = T::InputRef<'a>
-            where
-                Self: 'a;
-            type OutputRef<'a>
-                = T::OutputRef<'a>
-            where
-                Self: 'a;
 
             fn get_t_last(&self) -> f64 {
                 (**self).get_t_last()
@@ -182,30 +107,6 @@ macro_rules! impl_ref {
 
             fn set_t_next(&mut self, t_next: f64) {
                 (**self).set_t_next(t_next)
-            }
-
-            fn get_input(&self) -> &Self::Input {
-                (**self).get_input()
-            }
-
-            fn get_input_mut(&mut self) -> &mut Self::Input {
-                (**self).get_input_mut()
-            }
-
-            fn get_output(&self) -> &Self::Output {
-                (**self).get_output()
-            }
-
-            fn get_output_mut(&mut self) -> &mut Self::Output {
-                (**self).get_output_mut()
-            }
-
-            fn get_ports(&mut self) -> (Self::InputRef<'_>, Self::OutputRef<'_>) {
-                (**self).get_ports()
-            }
-
-            fn get_out_ports(&self) -> Self::OutputRef<'_> {
-                (**self).get_out_ports()
             }
         }
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -90,7 +90,7 @@ macro_rules! impl_ref {
     ( $ty:ty ) => {
         unsafe impl<T: Bag> Bag for $ty {
             fn build() -> Self {
-                unimplemented!("Cannot build a reference bag. This method should never be called.")
+                unreachable!("Cannot build a reference bag. This method should never be called.")
             }
 
             fn is_empty(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,15 +52,15 @@ pub trait Coupled: traits::PartialCoupled {
     /// External Input Coupling. Propagates input events from the coupled model to its inner components.
     #[allow(unused_variables)]
     #[inline]
-    fn eic(from: &Self::Input, to: &mut Self::ComponentsInput<'_>) {}
+    fn eic(from: &Self::Input, to: &mut Self::ComponentsInput) {}
 
     /// Internal Coupling. Propagates output events from inner components to input events of other inner components.
     #[allow(unused_variables)]
     #[inline]
-    fn ic(from: &Self::ComponentsOutput<'_>, to: &mut Self::ComponentsInput<'_>) {}
+    fn ic(from: &Self::ComponentsOutput, to: &mut Self::ComponentsInput) {}
 
     /// External Output Coupling. Propagates output events from inner components to the coupled model's output.
     #[allow(unused_variables)]
     #[inline]
-    fn eoc(from: &Self::ComponentsOutput<'_>, to: &mut Self::Output) {}
+    fn eoc(from: &Self::ComponentsOutput, to: &mut Self::Output) {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,10 @@ pub mod rt_engine;
 pub mod simulator;
 pub mod traits;
 
+pub use embassy_time::{Duration, Instant};
 pub use port::Port;
 pub use simulator::{Config, Simulator};
-pub use {embassy_time::Duration, embassy_time::Instant};
+
 /// Interface for DEVS atomic models. All DEVS atomic models must implement this trait.
 pub trait Atomic: traits::PartialAtomic {
     /// Method for performing any operation before simulating. By default, it does nothing.

--- a/src/port.rs
+++ b/src/port.rs
@@ -72,6 +72,10 @@ impl<T: Clone, const N: usize> Port<T, N> {
 }
 
 unsafe impl<T: Clone, const N: usize> crate::traits::Bag for Port<T, N> {
+    fn build() -> Self {
+        Self::new()
+    }
+
     fn is_empty(&self) -> bool {
         self.is_empty()
     }

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -86,16 +86,20 @@ impl<M: AbstractSimulator> Simulator<M> {
         let t_stop = config.t_stop;
         let mut t = t_start;
         let mut t_next_internal = self.model.start(t);
+        let mut component_input = <M::Input>::build();
+        let mut component_output = <M::Output>::build();
         while t < t_stop {
             let t_until = f64::min(t_next_internal, t_stop);
-            t = wait_until(t, t_until, self.model.get_input_mut());
+            t = wait_until(t, t_until, &mut component_input);
             if t >= t_next_internal {
-                self.model.lambda(t);
-                propagate_output(self.model.get_output());
-            } else if self.model.get_input().is_empty() {
+                self.model.lambda(&mut component_output, t);
+                propagate_output(&component_output);
+            } else if component_input.is_empty() {
                 continue; // avoid spurious external transitions
             }
-            t_next_internal = self.model.delta(t);
+            t_next_internal = self.model.delta(&component_input, t);
+            component_input.clear();
+            component_output.clear();
         }
         self.model.stop(t_stop);
     }
@@ -119,18 +123,22 @@ impl<M: AbstractSimulator> Simulator<M> {
     ) {
         let mut t = config.t_start;
         let mut t_next_internal = self.model.start(t);
+        let mut component_input = <M::Input>::build();
+        let mut component_output = <M::Output>::build();
         while t < config.t_stop {
             let t_until = f64::min(t_next_internal, config.t_stop);
             t = input_handler
-                .handle(config, t, t_until, self.model.get_input_mut())
+                .handle(config, t, t_until, &mut component_input)
                 .await;
             if t >= t_next_internal {
-                self.model.lambda(t);
-                propagate_output(self.model.get_output());
-            } else if self.model.get_input().is_empty() {
+                self.model.lambda(&mut component_output, t);
+                propagate_output(&component_output);
+            } else if component_input.is_empty() {
                 continue; // avoid spurious external transitions
             }
-            t_next_internal = self.model.delta(t);
+            t_next_internal = self.model.delta(&component_input, t);
+            component_input.clear();
+            component_output.clear();
         }
         self.model.stop(config.t_stop);
     }

--- a/src/simulator.rs
+++ b/src/simulator.rs
@@ -97,7 +97,9 @@ impl<M: AbstractSimulator> Simulator<M> {
             } else if component_input.is_empty() {
                 continue; // avoid spurious external transitions
             }
-            t_next_internal = self.model.delta(&component_input, t);
+            t_next_internal = self
+                .model
+                .delta(&mut component_input, &mut component_output, t);
             component_input.clear();
             component_output.clear();
         }
@@ -136,7 +138,9 @@ impl<M: AbstractSimulator> Simulator<M> {
             } else if component_input.is_empty() {
                 continue; // avoid spurious external transitions
             }
-            t_next_internal = self.model.delta(&component_input, t);
+            t_next_internal = self
+                .model
+                .delta(&mut component_input, &mut component_output, t);
             component_input.clear();
             component_output.clear();
         }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,6 @@
-use crate::{simulator::Config, traits::sealed::Sealed};
+use crate::simulator::Config;
 use core::future::Future;
+use sealed::Sealed;
 
 #[cfg(any(feature = "embassy", feature = "std"))]
 pub use crate::rt_engine::traits::{
@@ -58,16 +59,6 @@ pub unsafe trait Component {
     /// Output event bag of the model.
     type Output: Bag;
 
-    /// Reference returned by the `get_ports` method.
-    type InputRef<'a>
-    where
-        Self: 'a;
-
-    /// Reference returned by the `get_ports` method.
-    type OutputRef<'a>
-    where
-        Self: 'a;
-
     /// Returns the last time the component was updated.
     fn get_t_last(&self) -> f64;
 
@@ -79,36 +70,6 @@ pub unsafe trait Component {
 
     /// Sets the next time the component will be updated.
     fn set_t_next(&mut self, t_next: f64);
-
-    /// Returns a reference to the model's input event bag.
-    fn get_input(&self) -> &Self::Input;
-
-    /// Returns a mutable reference to the model's input event bag.
-    fn get_input_mut(&mut self) -> &mut Self::Input;
-
-    /// Returns a reference to the model's output event bag.
-    fn get_output(&self) -> &Self::Output;
-
-    /// Returns a mutable reference to the model's output event bag.
-    fn get_output_mut(&mut self) -> &mut Self::Output;
-
-    /// Returns both the input and output event bags as a tuple of references.
-    fn get_ports(&mut self) -> (Self::InputRef<'_>, Self::OutputRef<'_>);
-
-    /// Returns only the output event bag reference. Useful for output-only operations like lambda.
-    fn get_out_ports(&self) -> Self::OutputRef<'_>;
-
-    /// Clears the input bag, removing all values.
-    #[inline]
-    fn clear_input(&mut self) {
-        self.get_input_mut().clear()
-    }
-
-    /// Clears the output bag, removing all values.
-    #[inline]
-    fn clear_output(&mut self) {
-        self.get_output_mut().clear()
-    }
 }
 
 /// Partial interface for DEVS atomic models.
@@ -129,15 +90,11 @@ pub unsafe trait PartialAtomic: Component {
 ///
 /// This trait must be implemented via macros. Do not implement it manually.
 pub unsafe trait PartialCoupled: Component {
-    /// Wrapper type holding references to all inner components' inputs.
-    type ComponentsInput<'a>
-    where
-        Self: 'a;
+    /// Wrapper type holding all inner components' inputs.
+    type ComponentsInput;
 
-    /// Wrapper type holding references to all inner components' outputs.
-    type ComponentsOutput<'a>
-    where
-        Self: 'a;
+    /// Wrapper type holding all inner components' outputs.
+    type ComponentsOutput;
 }
 
 /// Interface for simulating DEVS models. All DEVS models must implement this trait.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -120,7 +120,7 @@ pub unsafe trait AbstractSimulator: Component {
     /// Propagates messages according to ICs and EICs, and executes state transition functions.
     /// Internally, it checks that the model is imminent before executing.
     /// Finally, it returns the time for the next state transition of the inner DEVS model.
-    fn delta(&mut self, input: &Self::Input, t: f64) -> f64;
+    fn delta(&mut self, input: &mut Self::Input, output: &mut Self::Output, t: f64) -> f64;
 }
 
 /// Interface for handling input events in an asynchronous DEVS simulation.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -117,8 +117,7 @@ pub unsafe trait AbstractSimulator: Component {
     /// Internally, it checks that the model is imminent before executing.
     fn lambda(&mut self, output: &mut Self::Output, t: f64);
 
-    /// Propagates messages according to ICs and EICs and executes model transition functions.
-    /// It also clears all the input and output ports.
+    /// Propagates messages according to ICs and EICs, and executes state transition functions.
     /// Internally, it checks that the model is imminent before executing.
     /// Finally, it returns the time for the next state transition of the inner DEVS model.
     fn delta(&mut self, input: &Self::Input, t: f64) -> f64;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -115,13 +115,13 @@ pub unsafe trait AbstractSimulator: Component {
 
     /// Executes output functions and propagates messages according to EOCs.
     /// Internally, it checks that the model is imminent before executing.
-    fn lambda(&mut self, t: f64);
+    fn lambda(&mut self, output: &mut Self::Output, t: f64);
 
     /// Propagates messages according to ICs and EICs and executes model transition functions.
     /// It also clears all the input and output ports.
     /// Internally, it checks that the model is imminent before executing.
     /// Finally, it returns the time for the next state transition of the inner DEVS model.
-    fn delta(&mut self, t: f64) -> f64;
+    fn delta(&mut self, input: &Self::Input, t: f64) -> f64;
 }
 
 /// Interface for handling input events in an asynchronous DEVS simulation.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -13,6 +13,9 @@ pub use crate::rt_engine::traits::{
 ///
 /// This trait must be implemented via macros. Do not implement it manually.
 pub unsafe trait Bag {
+    /// Build a new instance of the bag.
+    fn build() -> Self;
+
     /// Returns `true` if the ports are empty.
     fn is_empty(&self) -> bool;
 


### PR DESCRIPTION
Remove port visitors from DEVS models. 

Now the ports are owned by the external struct (be it a coupled model or the simulator) that owns the DEVS model. With this hierarchical structure, now the  external struct passes on references to their ports to the inner components.

This is expected to not only remove the visitors but to also increase performance as well.