### PR TITLE
Remove derives from ports and state

### DIFF
--- a/macros/src/component/port.rs
+++ b/macros/src/component/port.rs
@@ -55,7 +55,7 @@ impl Ports {
         };
 
         quote::quote! {
-            #[derive(Debug, Default, ::xdevs::Bag #bagmux)]
+            #[derive(::xdevs::Bag #bagmux)]
             pub struct #ident #impl_generics #where_clause {
                 #(pub #ports_ident: #ports_ty,)*
             }

--- a/macros/src/component/state.rs
+++ b/macros/src/component/state.rs
@@ -34,7 +34,6 @@ impl State {
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
 
         quote::quote! {
-            #[derive(Debug)]
             pub struct #ident #impl_generics #where_clause {
                 #(#fields_ident: #fields_ty,)*
             }


### PR DESCRIPTION
Remove mandatory support for Debug and Default in generated port structs and for Debug in the state struct.

These should not be mandatory, so they'll be remove until we decide on how the users can implement these derive traits if they want to.