### PR TITLE
New macro argument parsing method

### DIFF
--- a/macros/src/component.rs
+++ b/macros/src/component.rs
@@ -5,6 +5,8 @@ mod port;
 mod rt_engine;
 mod state;
 
+use crate::combine_err;
+
 use self::port::Ports;
 use backend::RtEngine;
 use proc_macro2::TokenStream as TokenStream2;
@@ -16,14 +18,6 @@ use syn::{
     Error, Field, GenericParam, Generics, Ident, ItemStruct, Lifetime, Meta, Result, Token, Type,
     TypeGenerics, TypePath,
 };
-
-/// Function to combine errors when parsing
-pub(crate) fn combine_err(acc: &mut Option<Error>, err: Error) {
-    match acc {
-        Some(e) => e.combine(err),
-        None => *acc = Some(err),
-    }
-}
 
 /// Arguments for both the `#[atomic]` and `#[coupled]` attribute macros.
 #[derive(Debug, Default)]
@@ -45,7 +39,7 @@ impl Parse for ComponentArgs {
                 if args.rt_engine.is_some() {
                     combine_err(
                         &mut acc,
-                        Error::new_spanned(&meta, "rt_engine argument already defined"),
+                        Error::new_spanned(&meta, "duplicate argument: rt_engine"),
                     );
                 } else {
                     match meta {
@@ -64,7 +58,7 @@ impl Parse for ComponentArgs {
                                 &mut acc,
                                 Error::new_spanned(
                                     nv,
-                                    "rt_engine does not expect a name-value pair",
+                                    "expected `rt_engine` or `rt_engine(...)`, found `rt_engine = ...`",
                                 ),
                             );
                         }

--- a/macros/src/component.rs
+++ b/macros/src/component.rs
@@ -10,13 +10,62 @@ use backend::RtEngine;
 use proc_macro2::TokenStream as TokenStream2;
 use std::collections::HashSet;
 use syn::{
-    parenthesized,
-    parse::{ParseStream, Parser},
-    token::Paren,
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
     visit::{self, Visit},
-    Error, Field, GenericParam, Generics, Ident, ItemStruct, Lifetime, Result, Type, TypeGenerics,
-    TypePath,
+    Error, Field, GenericParam, Generics, Ident, ItemStruct, Lifetime, Meta, Result, Token, Type,
+    TypeGenerics, TypePath,
 };
+
+/// Function to combine errors when parsing
+pub(crate) fn combine_err(acc: &mut Option<Error>, err: Error) {
+    match acc {
+        Some(e) => e.combine(err),
+        None => *acc = Some(err),
+    }
+}
+
+/// Arguments for both the `#[atomic]` and `#[coupled]` attribute macros.
+#[derive(Debug, Default)]
+pub struct ComponentArgs {
+    pub rt_engine: Option<RtEngine>,
+}
+
+impl Parse for ComponentArgs {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut args = ComponentArgs::default();
+
+        // Parse a comma-separated list of meta items (args)
+        let metas = Punctuated::<Meta, Token![,]>::parse_terminated(input)?;
+
+        for meta in metas {
+            // Check if the argument matches what we are looking for
+            if meta.path().is_ident("rt_engine") {
+                match meta {
+                    // Handles the case with no parenthesis: `#[component(rt_engine)]`
+                    Meta::Path(_) => {
+                        args.rt_engine = Some(RtEngine::default());
+                    }
+                    // Handles the parenthesized case: `#[component(rt_engine(...))]`
+                    Meta::List(list) => {
+                        args.rt_engine = Some(syn::parse2(list.tokens)?);
+                    }
+                    // Reject unsupported format `#[component(rt_engine = value)]`
+                    Meta::NameValue(nv) => {
+                        return Err(Error::new_spanned(
+                            nv,
+                            "rt_engine does not expect a name-value pair",
+                        ));
+                    }
+                }
+            } else {
+                return Err(Error::new_spanned(meta, "Unknown component argument"));
+            }
+        }
+
+        Ok(args)
+    }
+}
 
 /// Named struct field extracted from a component declaration.
 pub struct ComponentField {
@@ -34,45 +83,14 @@ pub struct Component {
 }
 
 impl Component {
-    fn parse_rt_engine(
-        args: TokenStream2,
-        unknown_arg_error: &'static str,
-    ) -> Result<Option<RtEngine>> {
-        let mut rt_engine = None;
-        Parser::parse2(
-            |input: ParseStream| -> Result<()> {
-                while !input.is_empty() {
-                    let ident: Ident = input.parse()?;
-                    if ident == "rt_engine" {
-                        // Accept both `rt_engine` and `rt_engine(...)`.
-                        if input.peek(Paren) {
-                            let content;
-                            parenthesized!(content in input);
-                            rt_engine = Some(content.parse::<RtEngine>()?);
-                        } else {
-                            rt_engine = Some(RtEngine::default());
-                        }
-                    } else {
-                        return Err(Error::new(ident.span(), unknown_arg_error));
-                    }
-                }
-                Ok(())
-            },
-            args,
-        )?;
-
-        Ok(rt_engine)
-    }
-
     pub fn new(
         ident: Ident,
         generics: Generics,
         inputs: Vec<ComponentField>,
         outputs: Vec<ComponentField>,
-        args: TokenStream2,
-        unknown_arg_error: &'static str,
+        args: ComponentArgs,
     ) -> Result<Self> {
-        let rt_engine = Self::parse_rt_engine(args, unknown_arg_error)?;
+        let rt_engine = args.rt_engine;
         let input_generics = filter_generics(&inputs, &generics);
         let output_generics = filter_generics(&outputs, &generics);
 

--- a/macros/src/component.rs
+++ b/macros/src/component.rs
@@ -29,6 +29,7 @@ impl Parse for ComponentArgs {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut acc: Option<Error> = None;
         let mut args = ComponentArgs::default();
+        let mut rt_engine_seen = false;
 
         // Parse a comma-separated list of meta items (args)
         let metas = Punctuated::<Meta, Token![,]>::parse_terminated(input)?;
@@ -36,12 +37,13 @@ impl Parse for ComponentArgs {
         for meta in metas {
             // Check if the argument matches what we are looking for
             if meta.path().is_ident("rt_engine") {
-                if args.rt_engine.is_some() {
+                if rt_engine_seen {
                     combine_err(
                         &mut acc,
                         Error::new_spanned(&meta, "duplicate argument: rt_engine"),
                     );
                 } else {
+                    rt_engine_seen = true;
                     match meta {
                         // Handles the case with no parenthesis: `#[component(rt_engine)]`
                         Meta::Path(_) => {

--- a/macros/src/component.rs
+++ b/macros/src/component.rs
@@ -42,21 +42,32 @@ impl Parse for ComponentArgs {
         for meta in metas {
             // Check if the argument matches what we are looking for
             if meta.path().is_ident("rt_engine") {
-                match meta {
-                    // Handles the case with no parenthesis: `#[component(rt_engine)]`
-                    Meta::Path(_) => {
-                        args.rt_engine = Some(RtEngine::default());
-                    }
-                    // Handles the parenthesized case: `#[component(rt_engine(...))]`
-                    Meta::List(list) => {
-                        args.rt_engine = Some(syn::parse2(list.tokens)?);
-                    }
-                    // Reject unsupported format `#[component(rt_engine = value)]`
-                    Meta::NameValue(nv) => {
-                        combine_err(
-                            &mut acc,
-                            Error::new_spanned(nv, "rt_engine does not expect a name-value pair"),
-                        );
+                if args.rt_engine.is_some() {
+                    combine_err(
+                        &mut acc,
+                        Error::new_spanned(&meta, "rt_engine argument already defined"),
+                    );
+                } else {
+                    match meta {
+                        // Handles the case with no parenthesis: `#[component(rt_engine)]`
+                        Meta::Path(_) => {
+                            args.rt_engine = Some(RtEngine::default());
+                        }
+                        // Handles the parenthesized case: `#[component(rt_engine(...))]`
+                        Meta::List(list) => match syn::parse2(list.tokens) {
+                            Ok(rt_engine) => args.rt_engine = Some(rt_engine),
+                            Err(err) => combine_err(&mut acc, err),
+                        },
+                        // Reject unsupported format `#[component(rt_engine = value)]`
+                        Meta::NameValue(nv) => {
+                            combine_err(
+                                &mut acc,
+                                Error::new_spanned(
+                                    nv,
+                                    "rt_engine does not expect a name-value pair",
+                                ),
+                            );
+                        }
                     }
                 }
             } else {

--- a/macros/src/component.rs
+++ b/macros/src/component.rs
@@ -25,7 +25,7 @@ pub struct ComponentField {
 }
 
 /// Shared metadata used by atomic and coupled component macro expansions.
-pub struct CommonComponent {
+pub struct Component {
     pub ident: Ident,
     pub generics: Generics,
     pub input: Ports,
@@ -33,7 +33,7 @@ pub struct CommonComponent {
     pub rt_engine: Option<RtEngine>,
 }
 
-impl CommonComponent {
+impl Component {
     fn parse_rt_engine(
         args: TokenStream2,
         unknown_arg_error: &'static str,

--- a/macros/src/component.rs
+++ b/macros/src/component.rs
@@ -33,6 +33,7 @@ pub struct ComponentArgs {
 
 impl Parse for ComponentArgs {
     fn parse(input: ParseStream) -> Result<Self> {
+        let mut acc: Option<Error> = None;
         let mut args = ComponentArgs::default();
 
         // Parse a comma-separated list of meta items (args)
@@ -52,15 +53,22 @@ impl Parse for ComponentArgs {
                     }
                     // Reject unsupported format `#[component(rt_engine = value)]`
                     Meta::NameValue(nv) => {
-                        return Err(Error::new_spanned(
-                            nv,
-                            "rt_engine does not expect a name-value pair",
-                        ));
+                        combine_err(
+                            &mut acc,
+                            Error::new_spanned(nv, "rt_engine does not expect a name-value pair"),
+                        );
                     }
                 }
             } else {
-                return Err(Error::new_spanned(meta, "Unknown component argument"));
+                combine_err(
+                    &mut acc,
+                    Error::new_spanned(meta, "Unknown component argument"),
+                );
             }
+        }
+
+        if let Some(err) = acc {
+            return Err(err);
         }
 
         Ok(args)

--- a/macros/src/component/atomic.rs
+++ b/macros/src/component/atomic.rs
@@ -43,13 +43,10 @@ impl Atomic {
         let generics = component.generics.clone();
         let state_generics = filter_generics(&state, &generics);
         let state_ident = Ident::new(&format!("{ident}State"), ident.span());
-        let common = Component::new(ident, generics, inputs, outputs, args)?;
+        let component = Component::new(ident, generics, inputs, outputs, args)?;
         let state = State::new(state, state_ident, state_generics);
 
-        Ok(Atomic {
-            component: common,
-            state,
-        })
+        Ok(Atomic { component, state })
     }
 
     pub fn quote(&self) -> TokenStream2 {

--- a/macros/src/component/atomic.rs
+++ b/macros/src/component/atomic.rs
@@ -10,7 +10,7 @@ use syn::{parse2, Error, Ident, ItemStruct, Result};
 
 /// Parsed representation of an atomic component macro input.
 pub struct Atomic {
-    pub common: Component,
+    pub component: Component,
     pub state: State,
 }
 
@@ -46,40 +46,43 @@ impl Atomic {
         let common = Component::new(ident, generics, inputs, outputs, args)?;
         let state = State::new(state, state_ident, state_generics);
 
-        Ok(Atomic { common, state })
+        Ok(Atomic {
+            component: common,
+            state,
+        })
     }
 
     pub fn quote(&self) -> TokenStream2 {
-        let ident = &self.common.ident;
+        let ident = &self.component.ident;
 
         // Prepare identifiers for code generation
-        let input_ident = &self.common.input.ident;
-        let output_ident = &self.common.output.ident;
+        let input_ident = &self.component.input.ident;
+        let output_ident = &self.component.output.ident;
         let state_ident = &self.state.ident;
         let state_fields = self.state.field_idents();
         let state_tys = self.state.field_tys();
 
         // Extract generics for impl
-        let (impl_generics, ty_generics, where_clause) = self.common.generics.split_for_impl();
-        let (_, input_generics, _) = &self.common.input.generics.split_for_impl();
-        let (_, output_generics, _) = &self.common.output.generics.split_for_impl();
+        let (impl_generics, ty_generics, where_clause) = self.component.generics.split_for_impl();
+        let (_, input_generics, _) = &self.component.input.generics.split_for_impl();
+        let (_, output_generics, _) = &self.component.output.generics.split_for_impl();
         let (_, state_generics, _) = &self.state.generics.split_for_impl();
 
         // Generate input, output, and state structs
-        let is_bagmux = self.common.rt_engine.is_some();
-        let input_struct = self.common.input.quote(is_bagmux);
-        let output_struct = self.common.output.quote(is_bagmux);
+        let is_bagmux = self.component.rt_engine.is_some();
+        let input_struct = self.component.input.quote(is_bagmux);
+        let output_struct = self.component.output.quote(is_bagmux);
         let state_struct = self.state.quote();
 
         // Generate rt_engine code if defined
-        let rt_engine_impl = self.common.quote_rt_engine();
+        let rt_engine_impl = self.component.quote_rt_engine();
 
         // Component trait implementation
         let component_impl = impl_component(
             ident,
             &input_ident,
             &output_ident,
-            &self.common.generics,
+            &self.component.generics,
             input_generics,
             output_generics,
         );

--- a/macros/src/component/atomic.rs
+++ b/macros/src/component/atomic.rs
@@ -1,18 +1,18 @@
 use super::filter_generics;
 use super::impl_component;
 use super::state::State;
-use super::CommonComponent;
+use super::Component;
 use super::ParsedComponentFields;
 use proc_macro2::TokenStream as TokenStream2;
 use syn::{parse2, Error, Ident, ItemStruct, Result};
 
 /// Parsed representation of an atomic component macro input.
-pub struct Component {
-    pub common: CommonComponent,
+pub struct Atomic {
+    pub common: Component,
     pub state: State,
 }
 
-impl Component {
+impl Atomic {
     pub fn parse(args: TokenStream2, item: TokenStream2) -> Result<Self> {
         let component: ItemStruct = parse2(item)?;
 
@@ -41,7 +41,7 @@ impl Component {
         let generics = component.generics.clone();
         let state_generics = filter_generics(&state, &generics);
         let state_ident = Ident::new(&format!("{ident}State"), ident.span());
-        let common = CommonComponent::new(
+        let common = Component::new(
             ident,
             generics,
             inputs,
@@ -51,7 +51,7 @@ impl Component {
         )?;
         let state = State::new(state, state_ident, state_generics);
 
-        Ok(Component { common, state })
+        Ok(Atomic { common, state })
     }
 
     pub fn quote(&self) -> TokenStream2 {

--- a/macros/src/component/atomic.rs
+++ b/macros/src/component/atomic.rs
@@ -1,3 +1,5 @@
+use crate::component::ComponentArgs;
+
 use super::filter_generics;
 use super::impl_component;
 use super::state::State;
@@ -13,7 +15,7 @@ pub struct Atomic {
 }
 
 impl Atomic {
-    pub fn parse(args: TokenStream2, item: TokenStream2) -> Result<Self> {
+    pub fn parse(args: ComponentArgs, item: TokenStream2) -> Result<Self> {
         let component: ItemStruct = parse2(item)?;
 
         let ident = component.ident.clone();
@@ -41,14 +43,7 @@ impl Atomic {
         let generics = component.generics.clone();
         let state_generics = filter_generics(&state, &generics);
         let state_ident = Ident::new(&format!("{ident}State"), ident.span());
-        let common = Component::new(
-            ident,
-            generics,
-            inputs,
-            outputs,
-            args,
-            "unknown atomic component argument",
-        )?;
+        let common = Component::new(ident, generics, inputs, outputs, args)?;
         let state = State::new(state, state_ident, state_generics);
 
         Ok(Atomic { common, state })

--- a/macros/src/component/backend.rs
+++ b/macros/src/component/backend.rs
@@ -19,10 +19,10 @@ pub use no_backend::RtEngineBackend as RtEngine;
 use proc_macro2::TokenStream as TokenStream2;
 use syn::{
     parse::{Parse, ParseStream},
-    Error, Ident, LitInt, Result, Token,
+    Error, Result, Token,
 };
 
-use crate::component::Component;
+use crate::component::{combine_err, Component};
 
 /// Generated token fragments used to construct backend channel code.
 pub struct ChannelTokens {
@@ -32,6 +32,7 @@ pub struct ChannelTokens {
 }
 
 /// Generic parsed arguments for `rt_engine(...)` backend configuration.
+#[derive(Default, Debug)] // Added Debug here too!
 pub struct RtEngineArgs {
     pub in_channel_size: Option<usize>,
     pub out_channel_size: Option<usize>,
@@ -40,60 +41,89 @@ pub struct RtEngineArgs {
 
 impl Parse for RtEngineArgs {
     fn parse(input: ParseStream) -> Result<Self> {
-        let mut in_channel_size = None;
-        let mut out_channel_size = None;
-        let mut max_out_subs = None;
+        let mut args = RtEngineArgs::default();
+        let mut acc: Option<Error> = None;
 
-        while !input.is_empty() {
-            let ident: Ident = input.parse()?;
-            input.parse::<Token![=]>()?;
-            let value: LitInt = input.parse()?;
-            let value: usize = value.base10_parse()?;
+        // Parse built-in Meta items
+        let parsed_args =
+            syn::punctuated::Punctuated::<syn::Meta, Token![,]>::parse_terminated(input)?;
 
-            match ident.to_string().as_str() {
+        for meta in parsed_args {
+            // We only care about `path = value` (MetaNameValue)
+            let nv = match meta {
+                syn::Meta::NameValue(nv) => nv,
+                _ => {
+                    let err = Error::new_spanned(meta, "expected `name = value` format");
+                    combine_err(&mut acc, err);
+                    continue;
+                }
+            };
+
+            let name = nv
+                .path
+                .require_ident()
+                .map(|i| i.to_string())
+                .unwrap_or_default();
+
+            // Extract the LitInt from the Expr
+            let lit_int = match &nv.value {
+                syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Int(lit),
+                    ..
+                }) => lit,
+                _ => {
+                    let err = Error::new_spanned(&nv.value, "expected an integer literal");
+                    combine_err(&mut acc, err);
+                    continue;
+                }
+            };
+
+            let value = match lit_int.base10_parse::<usize>() {
+                Ok(v) => v,
+                Err(e) => {
+                    let err = Error::new_spanned(lit_int, format!("invalid integer: {}", e));
+                    combine_err(&mut acc, err);
+                    continue;
+                }
+            };
+
+            match name.as_str() {
                 "in_channel_size" => {
-                    if in_channel_size.is_some() {
-                        return Err(Error::new(
-                            ident.span(),
-                            "duplicate argument: in_channel_size",
-                        ));
+                    if args.in_channel_size.is_some() {
+                        let err =
+                            Error::new_spanned(&nv.path, "duplicate argument: in_channel_size");
+                        combine_err(&mut acc, err);
                     }
-                    in_channel_size = Some(value);
+                    args.in_channel_size = Some(value);
                 }
                 "out_channel_size" => {
-                    if out_channel_size.is_some() {
-                        return Err(Error::new(
-                            ident.span(),
-                            "duplicate argument: out_channel_size",
-                        ));
+                    if args.out_channel_size.is_some() {
+                        let err =
+                            Error::new_spanned(&nv.path, "duplicate argument: out_channel_size");
+                        combine_err(&mut acc, err);
                     }
-                    out_channel_size = Some(value);
+                    args.out_channel_size = Some(value);
                 }
                 "max_out_subs" => {
-                    if max_out_subs.is_some() {
-                        return Err(Error::new(ident.span(), "duplicate argument: max_out_subs"));
+                    if args.max_out_subs.is_some() {
+                        let err = Error::new_spanned(&nv.path, "duplicate argument: max_out_subs");
+                        combine_err(&mut acc, err);
                     }
-                    max_out_subs = Some(value);
+                    args.max_out_subs = Some(value);
                 }
-                str => {
-                    return Err(Error::new(
-                        ident.span(),
-                        format!("unknown rt_engine argument: {str}"),
-                    ));
+                _ => {
+                    let err =
+                        Error::new_spanned(&nv.path, format!("unknown rt_engine argument: {name}"));
+                    combine_err(&mut acc, err);
                 }
-            }
-
-            // Require comma separator; allow optional trailing comma
-            if !input.is_empty() {
-                input.parse::<Token![,]>()?;
             }
         }
 
-        Ok(Self {
-            in_channel_size,
-            out_channel_size,
-            max_out_subs,
-        })
+        if let Some(err) = acc {
+            return Err(err);
+        }
+
+        Ok(args)
     }
 }
 

--- a/macros/src/component/backend.rs
+++ b/macros/src/component/backend.rs
@@ -22,7 +22,7 @@ use syn::{
     Error, Ident, LitInt, Result, Token,
 };
 
-use crate::component::CommonComponent;
+use crate::component::Component;
 
 /// Generated token fragments used to construct backend channel code.
 pub struct ChannelTokens {
@@ -31,7 +31,7 @@ pub struct ChannelTokens {
     pub private_channel: TokenStream2,
 }
 
-/// Generic parsed arguments for `rt_engine = { ... }` backend configuration.
+/// Generic parsed arguments for `rt_engine(...)` backend configuration.
 pub struct RtEngineArgs {
     pub in_channel_size: Option<usize>,
     pub out_channel_size: Option<usize>,
@@ -98,7 +98,7 @@ impl Parse for RtEngineArgs {
 }
 
 pub trait Backend {
-    fn check_compatibility(&self, model: &CommonComponent) -> Result<()>;
-    fn input_channel(&self, model: &CommonComponent) -> ChannelTokens;
-    fn output_channel(&self, model: &CommonComponent) -> ChannelTokens;
+    fn check_compatibility(&self, model: &Component) -> Result<()>;
+    fn input_channel(&self, model: &Component) -> ChannelTokens;
+    fn output_channel(&self, model: &Component) -> ChannelTokens;
 }

--- a/macros/src/component/backend.rs
+++ b/macros/src/component/backend.rs
@@ -22,7 +22,7 @@ use syn::{
     Error, Result, Token,
 };
 
-use crate::component::{combine_err, Component};
+use crate::{combine_err, component::Component};
 
 /// Generated token fragments used to construct backend channel code.
 pub struct ChannelTokens {
@@ -93,23 +93,26 @@ impl Parse for RtEngineArgs {
                         let err =
                             Error::new_spanned(&nv.path, "duplicate argument: in_channel_size");
                         combine_err(&mut acc, err);
+                    } else {
+                        args.in_channel_size = Some(value);
                     }
-                    args.in_channel_size = Some(value);
                 }
                 "out_channel_size" => {
                     if args.out_channel_size.is_some() {
                         let err =
                             Error::new_spanned(&nv.path, "duplicate argument: out_channel_size");
                         combine_err(&mut acc, err);
+                    } else {
+                        args.out_channel_size = Some(value);
                     }
-                    args.out_channel_size = Some(value);
                 }
                 "max_out_subs" => {
                     if args.max_out_subs.is_some() {
                         let err = Error::new_spanned(&nv.path, "duplicate argument: max_out_subs");
                         combine_err(&mut acc, err);
+                    } else {
+                        args.max_out_subs = Some(value);
                     }
-                    args.max_out_subs = Some(value);
                 }
                 _ => {
                     let err =

--- a/macros/src/component/backend/embassy.rs
+++ b/macros/src/component/backend/embassy.rs
@@ -7,6 +7,7 @@ use syn::{
 };
 
 /// Arguments for the `#[rt_engine]` attribute macro.
+#[derive(Debug)]
 pub struct RtEngineBackend {
     /// Capacity of the input channel (`in_channel_size = ...`).
     in_channel_size: usize,

--- a/macros/src/component/backend/embassy.rs
+++ b/macros/src/component/backend/embassy.rs
@@ -1,5 +1,5 @@
 use super::{Backend, ChannelTokens, RtEngineArgs};
-use crate::component::CommonComponent;
+use crate::component::Component;
 use heck::ToShoutySnakeCase;
 use syn::{
     parse::{Parse, ParseStream},
@@ -39,7 +39,7 @@ impl Parse for RtEngineBackend {
 }
 
 impl Backend for RtEngineBackend {
-    fn check_compatibility(&self, model: &CommonComponent) -> Result<()> {
+    fn check_compatibility(&self, model: &Component) -> Result<()> {
         let has_input_generics = !model.input.generics.params.is_empty();
         let has_output_generics = !model.output.generics.params.is_empty();
 
@@ -53,7 +53,7 @@ impl Backend for RtEngineBackend {
         }
     }
 
-    fn input_channel(&self, model: &CommonComponent) -> ChannelTokens {
+    fn input_channel(&self, model: &Component) -> ChannelTokens {
         let model_ident = &model.ident;
         let input_ident = &model.input.ident;
         let in_channel_size = self.in_channel_size;
@@ -81,7 +81,7 @@ impl Backend for RtEngineBackend {
         }
     }
 
-    fn output_channel(&self, model: &CommonComponent) -> ChannelTokens {
+    fn output_channel(&self, model: &Component) -> ChannelTokens {
         let model_ident = &model.ident;
         let output_ident = &model.output.ident;
         let out_channel_size = self.out_channel_size;

--- a/macros/src/component/backend/no_backend.rs
+++ b/macros/src/component/backend/no_backend.rs
@@ -7,6 +7,7 @@ use syn::{
 };
 
 /// Placeholder backend used when no backend feature is enabled.
+#[derive(Debug)]
 pub struct RtEngineBackend;
 
 impl Default for RtEngineBackend {

--- a/macros/src/component/backend/no_backend.rs
+++ b/macros/src/component/backend/no_backend.rs
@@ -1,5 +1,5 @@
 use super::{Backend, ChannelTokens, RtEngineArgs};
-use crate::component::CommonComponent;
+use crate::component::Component;
 use proc_macro2::TokenStream as TokenStream2;
 use syn::{
     parse::{Parse, ParseStream},
@@ -29,14 +29,14 @@ impl Parse for RtEngineBackend {
 }
 
 impl Backend for RtEngineBackend {
-    fn check_compatibility(&self, model: &CommonComponent) -> Result<()> {
+    fn check_compatibility(&self, model: &Component) -> Result<()> {
         Err(Error::new_spanned(
             &model.ident,
             "rt_engine requires enabling one backend feature: `std-backend` or `embassy-backend`",
         ))
     }
 
-    fn input_channel(&self, _model: &CommonComponent) -> ChannelTokens {
+    fn input_channel(&self, _model: &Component) -> ChannelTokens {
         ChannelTokens {
             channel_type: quote::quote! { () },
             channel_call: quote::quote! { () },
@@ -44,7 +44,7 @@ impl Backend for RtEngineBackend {
         }
     }
 
-    fn output_channel(&self, _model: &CommonComponent) -> ChannelTokens {
+    fn output_channel(&self, _model: &Component) -> ChannelTokens {
         ChannelTokens {
             channel_type: quote::quote! { () },
             channel_call: quote::quote! { () },

--- a/macros/src/component/backend/tokio.rs
+++ b/macros/src/component/backend/tokio.rs
@@ -1,5 +1,5 @@
 use super::{Backend, ChannelTokens, RtEngineArgs};
-use crate::component::CommonComponent;
+use crate::component::Component;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use syn::{
     parse::{Parse, ParseStream},
@@ -42,11 +42,11 @@ impl Parse for RtEngineBackend {
 }
 
 impl Backend for RtEngineBackend {
-    fn check_compatibility(&self, _: &CommonComponent) -> Result<()> {
+    fn check_compatibility(&self, _: &Component) -> Result<()> {
         Ok(())
     }
 
-    fn input_channel(&self, _model: &CommonComponent) -> ChannelTokens {
+    fn input_channel(&self, _model: &Component) -> ChannelTokens {
         let in_channel_size = self.in_channel_size;
         let channel_type = quote::quote! { ::xdevs::export::InputChannel<
             <Self as ::xdevs::traits::BagMux>::Mux,
@@ -61,7 +61,7 @@ impl Backend for RtEngineBackend {
         }
     }
 
-    fn output_channel(&self, _model: &CommonComponent) -> ChannelTokens {
+    fn output_channel(&self, _model: &Component) -> ChannelTokens {
         let out_channel_size = self.out_channel_size;
         let channel_type = quote::quote! { ::xdevs::export::OutputChannel<
             <Self as ::xdevs::traits::BagMux>::Mux,

--- a/macros/src/component/backend/tokio.rs
+++ b/macros/src/component/backend/tokio.rs
@@ -7,6 +7,7 @@ use syn::{
 };
 
 /// Arguments for the `#[rt_engine]` attribute macro.
+#[derive(Debug)]
 pub struct RtEngineBackend {
     /// Capacity of the input channel (`in_channel_size = ...`).
     in_channel_size: usize,

--- a/macros/src/component/coupled.rs
+++ b/macros/src/component/coupled.rs
@@ -47,11 +47,11 @@ impl Coupled {
         let components_ident = Ident::new(&format!("{}Components", &ident), ident.span());
 
         // Generate common component and components
-        let common = Component::new(ident, generics, inputs, outputs, args)?;
+        let component = Component::new(ident, generics, inputs, outputs, args)?;
         let components = Components::new(components, components_ident, components_generics);
 
         Ok(Coupled {
-            component: common,
+            component,
             components,
         })
     }

--- a/macros/src/component/coupled.rs
+++ b/macros/src/component/coupled.rs
@@ -2,19 +2,19 @@ mod components;
 
 use super::filter_generics;
 use super::impl_component;
-use super::CommonComponent;
+use super::Component;
 use super::ParsedComponentFields;
 use components::Components;
 use proc_macro2::TokenStream as TokenStream2;
 use syn::{parse2, Error, Ident, ItemStruct, Result};
 
 /// Parsed representation of a coupled2 component macro input.
-pub struct Component {
-    pub common: CommonComponent,
+pub struct Coupled {
+    pub common: Component,
     pub components: Components,
 }
 
-impl Component {
+impl Coupled {
     pub fn parse(args: TokenStream2, item: TokenStream2) -> Result<Self> {
         let component: ItemStruct = parse2(item)?;
 
@@ -45,7 +45,7 @@ impl Component {
         let components_ident = Ident::new(&format!("{}Components", &ident), ident.span());
 
         // Generate common component and components
-        let common = CommonComponent::new(
+        let common = Component::new(
             ident,
             generics,
             inputs,
@@ -55,7 +55,7 @@ impl Component {
         )?;
         let components = Components::new(components, components_ident, components_generics);
 
-        Ok(Component { common, components })
+        Ok(Coupled { common, components })
     }
 
     pub fn quote(&self) -> TokenStream2 {

--- a/macros/src/component/coupled.rs
+++ b/macros/src/component/coupled.rs
@@ -10,9 +10,9 @@ use components::Components;
 use proc_macro2::TokenStream as TokenStream2;
 use syn::{parse2, Error, Ident, ItemStruct, Result};
 
-/// Parsed representation of a coupled2 component macro input.
+/// Parsed representation of a coupled component macro input.
 pub struct Coupled {
-    pub common: Component,
+    pub component: Component,
     pub components: Components,
 }
 
@@ -50,52 +50,55 @@ impl Coupled {
         let common = Component::new(ident, generics, inputs, outputs, args)?;
         let components = Components::new(components, components_ident, components_generics);
 
-        Ok(Coupled { common, components })
+        Ok(Coupled {
+            component: common,
+            components,
+        })
     }
 
     pub fn quote(&self) -> TokenStream2 {
-        let ident = &self.common.ident;
+        let ident = &self.component.ident;
 
         // Prepare identifiers for code generation
         let input_ident = Ident::new(
-            &format!("{}Input", &self.common.ident),
-            self.common.ident.span(),
+            &format!("{}Input", &self.component.ident),
+            self.component.ident.span(),
         );
         let output_ident = Ident::new(
-            &format!("{}Output", &self.common.ident),
-            self.common.ident.span(),
+            &format!("{}Output", &self.component.ident),
+            self.component.ident.span(),
         );
         let components_ident = Ident::new(
-            &format!("{}Components", &self.common.ident),
-            self.common.ident.span(),
+            &format!("{}Components", &self.component.ident),
+            self.component.ident.span(),
         );
         let components_fields = self.components.field_idents();
         let components_tys = self.components.field_tys();
 
         // Extract generics for impl
-        let (impl_generics, ty_generics, where_clause) = self.common.generics.split_for_impl();
-        let (_, input_ty_generics, _) = &self.common.input.generics.split_for_impl();
-        let (_, output_ty_generics, _) = &self.common.output.generics.split_for_impl();
+        let (impl_generics, ty_generics, where_clause) = self.component.generics.split_for_impl();
+        let (_, input_ty_generics, _) = &self.component.input.generics.split_for_impl();
+        let (_, output_ty_generics, _) = &self.component.output.generics.split_for_impl();
         let (components_impl_generics, components_ty_generics, components_where_clause) =
             &self.components.generics.split_for_impl();
 
         // Generate input, output, and components structs
-        let is_bagmux = self.common.rt_engine.is_some();
-        let input_struct = self.common.input.quote(is_bagmux);
-        let output_struct = self.common.output.quote(is_bagmux);
+        let is_bagmux = self.component.rt_engine.is_some();
+        let input_struct = self.component.input.quote(is_bagmux);
+        let output_struct = self.component.output.quote(is_bagmux);
         let components_struct = self.components.quote();
         // Component trait implementation
         let component_impl = impl_component(
             ident,
             &input_ident,
             &output_ident,
-            &self.common.generics,
+            &self.component.generics,
             input_ty_generics,
             output_ty_generics,
         );
 
         // Generate rt_engine code if defined
-        let rt_engine_impl = self.common.quote_rt_engine();
+        let rt_engine_impl = self.component.quote_rt_engine();
 
         // Generate wrapper structs for inner components' inputs and outputs
         // These structs hold all inner components' inputs/outputs,

--- a/macros/src/component/coupled.rs
+++ b/macros/src/component/coupled.rs
@@ -1,5 +1,7 @@
 mod components;
 
+use crate::component::ComponentArgs;
+
 use super::filter_generics;
 use super::impl_component;
 use super::Component;
@@ -15,7 +17,7 @@ pub struct Coupled {
 }
 
 impl Coupled {
-    pub fn parse(args: TokenStream2, item: TokenStream2) -> Result<Self> {
+    pub fn parse(args: ComponentArgs, item: TokenStream2) -> Result<Self> {
         let component: ItemStruct = parse2(item)?;
 
         let ident = component.ident.clone();
@@ -45,14 +47,7 @@ impl Coupled {
         let components_ident = Ident::new(&format!("{}Components", &ident), ident.span());
 
         // Generate common component and components
-        let common = Component::new(
-            ident,
-            generics,
-            inputs,
-            outputs,
-            args,
-            "unknown coupled component argument",
-        )?;
+        let common = Component::new(ident, generics, inputs, outputs, args)?;
         let components = Components::new(components, components_ident, components_generics);
 
         Ok(Coupled { common, components })

--- a/macros/src/component/rt_engine.rs
+++ b/macros/src/component/rt_engine.rs
@@ -1,8 +1,8 @@
-use super::{backend::Backend, CommonComponent};
+use super::{backend::Backend, Component};
 use heck::ToSnakeCase;
 use proc_macro2::TokenStream as TokenStream2;
 
-impl CommonComponent {
+impl Component {
     /// Generate the rt-engine infrastructure code:
     pub fn quote_rt_engine(&self) -> TokenStream2 {
         if let Some(rt_engine) = &self.rt_engine {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,5 +1,5 @@
 use proc_macro::TokenStream;
-use syn::parse_macro_input;
+use syn::{parse_macro_input, Error};
 
 mod component;
 mod derive;
@@ -39,5 +39,13 @@ pub fn derive_bagmux(input: TokenStream) -> TokenStream {
     match derive::derive_bagmux(input) {
         Ok(tokens) => tokens.into(),
         Err(err) => err.to_compile_error().into(),
+    }
+}
+
+/// Function to combine errors when parsing
+pub(crate) fn combine_err(acc: &mut Option<Error>, err: Error) {
+    match acc {
+        Some(e) => e.combine(err),
+        None => *acc = Some(err),
     }
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -5,7 +5,7 @@ mod derive;
 
 #[proc_macro_attribute]
 pub fn atomic(args: TokenStream, item: TokenStream) -> TokenStream {
-    let atomic_component = component::atomic::Component::parse(args.into(), item.into());
+    let atomic_component = component::atomic::Atomic::parse(args.into(), item.into());
     match atomic_component {
         Ok(component) => component.quote().into(),
         Err(err) => err.to_compile_error().into(),
@@ -14,7 +14,7 @@ pub fn atomic(args: TokenStream, item: TokenStream) -> TokenStream {
 
 #[proc_macro_attribute]
 pub fn coupled(args: TokenStream, item: TokenStream) -> TokenStream {
-    let coupled_component = component::coupled::Component::parse(args.into(), item.into());
+    let coupled_component = component::coupled::Coupled::parse(args.into(), item.into());
     match coupled_component {
         Ok(component) => component.quote().into(),
         Err(err) => err.to_compile_error().into(),

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,11 +1,13 @@
 use proc_macro::TokenStream;
+use syn::parse_macro_input;
 
 mod component;
 mod derive;
 
 #[proc_macro_attribute]
 pub fn atomic(args: TokenStream, item: TokenStream) -> TokenStream {
-    let atomic_component = component::atomic::Atomic::parse(args.into(), item.into());
+    let args = parse_macro_input!(args as component::ComponentArgs);
+    let atomic_component = component::atomic::Atomic::parse(args, item.into());
     match atomic_component {
         Ok(component) => component.quote().into(),
         Err(err) => err.to_compile_error().into(),
@@ -14,7 +16,8 @@ pub fn atomic(args: TokenStream, item: TokenStream) -> TokenStream {
 
 #[proc_macro_attribute]
 pub fn coupled(args: TokenStream, item: TokenStream) -> TokenStream {
-    let coupled_component = component::coupled::Coupled::parse(args.into(), item.into());
+    let args = parse_macro_input!(args as component::ComponentArgs);
+    let coupled_component = component::coupled::Coupled::parse(args, item.into());
     match coupled_component {
         Ok(component) => component.quote().into(),
         Err(err) => err.to_compile_error().into(),


### PR DESCRIPTION
Centralize all macro arguments (currently only rt_engine) and separate its parsing function from that of the struct body.