### PR TITLE
Clean quotes and apply visibility

### DIFF
--- a/examples/gpt.rs
+++ b/examples/gpt.rs
@@ -1,11 +1,11 @@
 /// A simple DEVS GPT model
 mod generator {
     #[xdevs::atomic]
-    struct Generator {
+    pub struct Generator {
         #[input]
-        in_stop: xdevs::port::Port<bool, 1>,
+        pub in_stop: xdevs::port::Port<bool, 1>,
         #[output]
-        out_job: xdevs::port::Port<usize, 1>,
+        pub out_job: xdevs::port::Port<usize, 1>,
         #[state]
         sigma: f64,
         period: f64,
@@ -47,11 +47,11 @@ mod generator {
 
 mod processor {
     #[xdevs::atomic]
-    struct Processor {
+    pub struct Processor {
         #[input]
-        in_job: xdevs::port::Port<usize, 1>,
+        pub in_job: xdevs::port::Port<usize, 1>,
         #[output]
-        out_job: xdevs::port::Port<usize, 1>,
+        pub out_job: xdevs::port::Port<usize, 1>,
         #[state]
         sigma: f64,
         time: f64,
@@ -101,12 +101,12 @@ mod processor {
 
 mod transducer {
     #[xdevs::atomic]
-    struct Transducer {
+    pub struct Transducer {
         #[input]
-        in_generator: xdevs::port::Port<usize, 1>,
-        in_processor: xdevs::port::Port<usize, 1>,
+        pub in_generator: xdevs::port::Port<usize, 1>,
+        pub in_processor: xdevs::port::Port<usize, 1>,
         #[output]
-        out_stop: xdevs::port::Port<bool, 1>,
+        pub out_stop: xdevs::port::Port<bool, 1>,
         #[state]
         sigma: f64,
         clock: f64,
@@ -156,7 +156,7 @@ mod transducer {
 }
 
 #[xdevs::coupled]
-struct GPT {
+pub struct GPT {
     #[components]
     generator: generator::Generator,
     processor: processor::Processor,
@@ -220,7 +220,7 @@ impl xdevs::Coupled for EF {
 }
 
 #[xdevs::coupled]
-struct EFP {
+pub struct EFP {
     #[components]
     ef: EF,
     processor: processor::Processor,

--- a/examples/gpt_async.rs
+++ b/examples/gpt_async.rs
@@ -3,11 +3,11 @@ use xdevs::simulator::{std::SleepAsync, Config, Simulator};
 
 mod generator {
     #[xdevs::atomic]
-    struct Generator {
+    pub struct Generator {
         #[input]
-        in_stop: xdevs::port::Port<bool, 1>,
+        pub in_stop: xdevs::port::Port<bool, 1>,
         #[output]
-        out_job: xdevs::port::Port<usize, 1>,
+        pub out_job: xdevs::port::Port<usize, 1>,
         #[state]
         sigma: f64,
         period: f64,
@@ -49,11 +49,11 @@ mod generator {
 
 mod processor {
     #[xdevs::atomic]
-    struct Processor {
+    pub struct Processor {
         #[input]
-        in_job: xdevs::port::Port<usize, 1>,
+        pub in_job: xdevs::port::Port<usize, 1>,
         #[output]
-        out_job: xdevs::port::Port<usize, 1>,
+        pub out_job: xdevs::port::Port<usize, 1>,
         #[state]
         sigma: f64,
         time: f64,
@@ -103,12 +103,12 @@ mod processor {
 
 mod transducer {
     #[xdevs::atomic]
-    struct Transducer {
+    pub struct Transducer {
         #[input]
-        in_generator: xdevs::port::Port<usize, 1>,
-        in_processor: xdevs::port::Port<usize, 1>,
+        pub in_generator: xdevs::port::Port<usize, 1>,
+        pub in_processor: xdevs::port::Port<usize, 1>,
         #[output]
-        out_stop: xdevs::port::Port<bool, 1>,
+        pub out_stop: xdevs::port::Port<bool, 1>,
         #[state]
         sigma: f64,
         clock: f64,
@@ -158,7 +158,7 @@ mod transducer {
 }
 
 #[xdevs::coupled]
-struct GPT {
+pub struct GPT {
     #[components]
     generator: generator::Generator,
     processor: processor::Processor,
@@ -222,7 +222,7 @@ impl xdevs::Coupled for EF {
 }
 
 #[xdevs::coupled]
-struct EFP {
+pub struct EFP {
     #[components]
     ef: EF,
     processor: processor::Processor,

--- a/macros/src/component.rs
+++ b/macros/src/component.rs
@@ -103,7 +103,7 @@ impl Parse for ComponentArgs {
 /// Named struct field extracted from a component declaration.
 pub struct ComponentField {
     pub ident: Ident,
-    pub _vis: Visibility,
+    pub vis: Visibility,
     pub ty: Type,
     pub attr: Attribute,
 }
@@ -153,7 +153,7 @@ impl ComponentField {
         }
         Ok(Self {
             ident,
-            _vis: field.vis.clone(),
+            vis: field.vis.clone(),
             ty: field.ty.clone(),
             attr,
         })
@@ -177,7 +177,7 @@ impl ComponentField {
 /// Shared metadata used by atomic and coupled component macro expansions.
 pub struct Component {
     pub ident: Ident,
-    pub _vis: Visibility,
+    pub vis: Visibility,
     pub generics: Generics,
     pub input: Ports,
     pub output: Ports,
@@ -261,7 +261,7 @@ impl Component {
 
         Ok(Self {
             ident: ident.clone(),
-            _vis: item.vis.clone(),
+            vis: item.vis.clone(),
             generics: generics.clone(),
             input,
             output,

--- a/macros/src/component/atomic.rs
+++ b/macros/src/component/atomic.rs
@@ -71,9 +71,9 @@ impl Atomic {
 
         // Generate input, output, and state structs
         let is_bagmux = component.rt_engine.is_some();
-        let input_struct = input.quote(is_bagmux);
-        let output_struct = output.quote(is_bagmux);
-        let state_struct = state.quote();
+        let input_struct = input.quote(is_bagmux, &vis);
+        let output_struct = output.quote(is_bagmux, &vis);
+        let state_struct = state.quote(&vis);
 
         // Generate rt_engine code if defined
         let rt_engine_impl = component.quote_rt_engine();

--- a/macros/src/component/atomic.rs
+++ b/macros/src/component/atomic.rs
@@ -46,38 +46,45 @@ impl Atomic {
     }
 
     pub fn quote(&self) -> TokenStream2 {
-        let ident = &self.component.ident;
+        let component = &self.component;
+
+        let ident = &component.ident;
 
         // Prepare identifiers for code generation
-        let input_ident = &self.component.input.ident;
-        let output_ident = &self.component.output.ident;
-        let state_ident = &self.component.state.ident;
-        let state_fields = self.component.state.field_idents();
-        let state_tys = self.component.state.field_tys();
+        let input = &component.input;
+        let output = &component.output;
+        let state = &component.state;
+
+        let input_ident = &input.ident;
+        let output_ident = &output.ident;
+        let state_ident = &state.ident;
+
+        let state_fields = state.field_idents();
+        let state_tys = state.field_tys();
 
         // Extract generics for impl
-        let (impl_generics, ty_generics, where_clause) = self.component.generics.split_for_impl();
-        let (_, input_generics, _) = &self.component.input.generics.split_for_impl();
-        let (_, output_generics, _) = &self.component.output.generics.split_for_impl();
-        let (_, state_generics, _) = &self.component.state.generics.split_for_impl();
+        let (impl_generics, ty_generics, where_clause) = component.generics.split_for_impl();
+        let (_, input_generics, _) = input.generics.split_for_impl();
+        let (_, output_generics, _) = output.generics.split_for_impl();
+        let (_, state_generics, _) = state.generics.split_for_impl();
 
         // Generate input, output, and state structs
-        let is_bagmux = self.component.rt_engine.is_some();
-        let input_struct = self.component.input.quote(is_bagmux);
-        let output_struct = self.component.output.quote(is_bagmux);
-        let state_struct = self.component.state.quote();
+        let is_bagmux = component.rt_engine.is_some();
+        let input_struct = input.quote(is_bagmux);
+        let output_struct = output.quote(is_bagmux);
+        let state_struct = state.quote();
 
         // Generate rt_engine code if defined
-        let rt_engine_impl = self.component.quote_rt_engine();
+        let rt_engine_impl = component.quote_rt_engine();
 
         // Component trait implementation
         let component_impl = impl_component(
             ident,
-            &input_ident,
-            &output_ident,
-            &self.component.generics,
-            input_generics,
-            output_generics,
+            input_ident,
+            output_ident,
+            &component.generics,
+            &input_generics,
+            &output_generics,
         );
 
         // Generate the expanded code

--- a/macros/src/component/atomic.rs
+++ b/macros/src/component/atomic.rs
@@ -48,6 +48,7 @@ impl Atomic {
     pub fn quote(&self) -> TokenStream2 {
         let component = &self.component;
 
+        let vis = &component.vis;
         let ident = &component.ident;
 
         // Prepare identifiers for code generation
@@ -93,10 +94,10 @@ impl Atomic {
             #output_struct
             #state_struct
             #rt_engine_impl
-            pub struct #ident #impl_generics #where_clause {
-                pub t_last: f64,
-                pub t_next: f64,
-                pub state: #state_ident #state_generics,
+            #vis struct #ident #impl_generics #where_clause {
+                t_last: f64,
+                t_next: f64,
+                state: #state_ident #state_generics,
             }
             impl #impl_generics #ident #ty_generics #where_clause {
                 #[inline]

--- a/macros/src/component/coupled.rs
+++ b/macros/src/component/coupled.rs
@@ -46,6 +46,7 @@ impl Coupled {
     pub fn quote(&self) -> TokenStream2 {
         let component = &self.component;
 
+        let vis = &component.vis;
         let ident = &component.ident;
         let span = ident.span();
 
@@ -139,12 +140,12 @@ impl Coupled {
                 #(#components_output_fields),*
             }
 
-            pub struct #ident #impl_generics #where_clause {
-                pub components_input: #components_input_ident #components_ty_generics,
-                pub components_output: #components_output_ident #components_ty_generics,
-                pub t_last: f64,
-                pub t_next: f64,
-                pub components: #components_ident #components_ty_generics,
+            #vis struct #ident #impl_generics #where_clause {
+                components_input: #components_input_ident #components_ty_generics,
+                components_output: #components_output_ident #components_ty_generics,
+                t_last: f64,
+                t_next: f64,
+                components: #components_ident #components_ty_generics,
             }
             impl #impl_generics #ident #ty_generics #where_clause {
                 #[inline]

--- a/macros/src/component/coupled.rs
+++ b/macros/src/component/coupled.rs
@@ -44,85 +44,81 @@ impl Coupled {
     }
 
     pub fn quote(&self) -> TokenStream2 {
-        let ident = &self.component.ident;
+        let component = &self.component;
+
+        let ident = &component.ident;
+        let span = ident.span();
 
         // Prepare identifiers for code generation
-        let input_ident = Ident::new(
-            &format!("{}Input", &self.component.ident),
-            self.component.ident.span(),
-        );
-        let output_ident = Ident::new(
-            &format!("{}Output", &self.component.ident),
-            self.component.ident.span(),
-        );
-        let components_ident = Ident::new(
-            &format!("{}Components", &self.component.ident),
-            self.component.ident.span(),
-        );
-        let components_fields = self.component.components.field_idents();
-        let components_tys = self.component.components.field_tys();
+        let input = &component.input;
+        let output = &component.output;
+        let components = &component.components;
+
+        let input_ident = &input.ident;
+        let output_ident = &output.ident;
+        let components_ident = &components.ident;
+
+        let components_fields = components.field_idents();
+        let components_tys = components.field_tys();
 
         // Extract generics for impl
-        let (impl_generics, ty_generics, where_clause) = self.component.generics.split_for_impl();
-        let (_, input_ty_generics, _) = &self.component.input.generics.split_for_impl();
-        let (_, output_ty_generics, _) = &self.component.output.generics.split_for_impl();
+        let (impl_generics, ty_generics, where_clause) = component.generics.split_for_impl();
+        let (_, input_ty_generics, _) = input.generics.split_for_impl();
+        let (_, output_ty_generics, _) = output.generics.split_for_impl();
+
         let (components_impl_generics, components_ty_generics, components_where_clause) =
-            &self.component.components.generics.split_for_impl();
+            components.generics.split_for_impl();
 
         // Generate input, output, and components structs
-        let is_bagmux = self.component.rt_engine.is_some();
-        let input_struct = self.component.input.quote(is_bagmux);
-        let output_struct = self.component.output.quote(is_bagmux);
-        let components_struct = self.component.components.quote();
+        let is_bagmux = component.rt_engine.is_some();
+
+        let input_struct = input.quote(is_bagmux);
+        let output_struct = output.quote(is_bagmux);
+        let components_struct = components.quote();
+
         // Component trait implementation
         let component_impl = impl_component(
             ident,
             &input_ident,
             &output_ident,
-            &self.component.generics,
-            input_ty_generics,
-            output_ty_generics,
+            &component.generics,
+            &input_ty_generics,
+            &output_ty_generics,
         );
 
         // Generate rt_engine code if defined
-        let rt_engine_impl = self.component.quote_rt_engine();
+        let rt_engine_impl = component.quote_rt_engine();
 
-        // Generate wrapper structs for inner components' inputs and outputs
+        // Generate wrapper structs for inner components' inputs and outputs.
         // These structs hold all inner components' inputs/outputs,
         // allowing them to be passed as a single argument to trait methods.
-        let components_input_ident = Ident::new(&format!("{}ComponentsInput", ident), ident.span());
-        let components_output_ident =
-            Ident::new(&format!("{}ComponentsOutput", ident), ident.span());
-
-        let components_input_fields: Vec<TokenStream2> = self
-            .component
-            .components
+        let components_input_ident = Ident::new(&format!("{ident}ComponentsInput"), span);
+        let components_output_ident = Ident::new(&format!("{ident}ComponentsOutput"), span);
+        let components_input_fields: Vec<TokenStream2> = components
             .fields
             .iter()
             .map(|field| {
                 let field_ident = &field.ident;
                 let field_ty = &field.ty;
+
                 quote::quote! {
                     pub #field_ident: <#field_ty as ::xdevs::traits::Component>::Input
                 }
             })
             .collect();
 
-        let components_output_fields: Vec<TokenStream2> = self
-            .component
-            .components
+        let components_output_fields: Vec<TokenStream2> = components
             .fields
             .iter()
             .map(|field| {
                 let field_ident = &field.ident;
                 let field_ty = &field.ty;
+
                 quote::quote! {
                     pub #field_ident: <#field_ty as ::xdevs::traits::Component>::Output
                 }
             })
             .collect();
-
-        // Generate struct definition generics and usage generics for ComponentsInput/ComponentsOutput
 
         // Generate the expanded code
         let expanded = quote::quote! {

--- a/macros/src/component/coupled.rs
+++ b/macros/src/component/coupled.rs
@@ -73,9 +73,9 @@ impl Coupled {
         // Generate input, output, and components structs
         let is_bagmux = component.rt_engine.is_some();
 
-        let input_struct = input.quote(is_bagmux);
-        let output_struct = output.quote(is_bagmux);
-        let components_struct = components.quote();
+        let input_struct = input.quote(is_bagmux, &vis);
+        let output_struct = output.quote(is_bagmux, &vis);
+        let components_struct = components.quote(&vis);
 
         // Component trait implementation
         let component_impl = impl_component(

--- a/macros/src/component/coupled/components.rs
+++ b/macros/src/component/coupled/components.rs
@@ -18,6 +18,10 @@ impl Components {
         }
     }
 
+    pub fn field_vis(&self) -> Vec<&syn::Visibility> {
+        self.fields.iter().map(|f| &f.vis).collect()
+    }
+
     pub fn field_idents(&self) -> Vec<&Ident> {
         self.fields.iter().map(|f| &f.ident).collect()
     }
@@ -28,13 +32,15 @@ impl Components {
 
     pub fn quote(&self) -> TokenStream2 {
         let ident = &self.ident;
+        let fields_vis = self.field_vis();
         let fields_ident = self.field_idents();
         let fields_ty = self.field_tys();
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
 
+        // TODO determine what to do with components struct visibility
         quote::quote! {
             pub struct #ident #impl_generics #where_clause{
-                #(#fields_ident: #fields_ty,)*
+                #(#fields_vis #fields_ident: #fields_ty,)*
             }
             impl #impl_generics #ident #ty_generics #where_clause {
                 #[inline]

--- a/macros/src/component/coupled/components.rs
+++ b/macros/src/component/coupled/components.rs
@@ -1,6 +1,6 @@
 use crate::component::ComponentField;
 use proc_macro2::TokenStream as TokenStream2;
-use syn::{Generics, Ident, Type};
+use syn::{Generics, Ident, Type, Visibility};
 
 /// Parsed inner component fields for coupled2 model generation.
 pub struct Components {
@@ -30,7 +30,7 @@ impl Components {
         self.fields.iter().map(|f| &f.ty).collect()
     }
 
-    pub fn quote(&self) -> TokenStream2 {
+    pub fn quote(&self, vis: &Visibility) -> TokenStream2 {
         let ident = &self.ident;
         let fields_vis = self.field_vis();
         let fields_ident = self.field_idents();
@@ -39,7 +39,7 @@ impl Components {
 
         // TODO determine what to do with components struct visibility
         quote::quote! {
-            pub struct #ident #impl_generics #where_clause{
+            #vis struct #ident #impl_generics #where_clause{
                 #(#fields_vis #fields_ident: #fields_ty,)*
             }
             impl #impl_generics #ident #ty_generics #where_clause {

--- a/macros/src/component/port.rs
+++ b/macros/src/component/port.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream as TokenStream2;
-use syn::{Expr, ExprLit, Generics, Ident, Lit, PathArguments, Type};
+use syn::{Expr, ExprLit, Generics, Ident, Lit, PathArguments, Type, Visibility};
 
 use super::ComponentField;
 
@@ -44,7 +44,7 @@ impl Ports {
         news
     }
 
-    pub fn quote(&self, is_bagmux: bool) -> TokenStream2 {
+    pub fn quote(&self, is_bagmux: bool, vis: &Visibility) -> TokenStream2 {
         let ident = &self.ident;
         let ports_vis = self.field_vis();
         let ports_ident = self.field_idents();
@@ -62,7 +62,7 @@ impl Ports {
         // TODO determine what to do with ports struct visibility
         quote::quote! {
             #[derive(::xdevs::Bag #bagmux)]
-            pub struct #ident #impl_generics #where_clause {
+            #vis struct #ident #impl_generics #where_clause {
                 #(#ports_vis #ports_ident: #ports_ty,)*
             }
             impl #impl_generics #ident #ty_generics #where_clause {

--- a/macros/src/component/port.rs
+++ b/macros/src/component/port.rs
@@ -19,11 +19,15 @@ impl Ports {
         }
     }
 
-    fn field_idents(&self) -> Vec<&Ident> {
+    pub fn field_vis(&self) -> Vec<&syn::Visibility> {
+        self.fields.iter().map(|f| &f.vis).collect()
+    }
+
+    pub fn field_idents(&self) -> Vec<&Ident> {
         self.fields.iter().map(|f| &f.ident).collect()
     }
 
-    fn field_tys(&self) -> Vec<&Type> {
+    pub fn field_tys(&self) -> Vec<&Type> {
         self.fields.iter().map(|f| &f.ty).collect()
     }
 
@@ -42,6 +46,7 @@ impl Ports {
 
     pub fn quote(&self, is_bagmux: bool) -> TokenStream2 {
         let ident = &self.ident;
+        let ports_vis = self.field_vis();
         let ports_ident = self.field_idents();
         let ports_ty = self.field_tys();
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
@@ -54,10 +59,11 @@ impl Ports {
             TokenStream2::new()
         };
 
+        // TODO determine what to do with ports struct visibility
         quote::quote! {
             #[derive(::xdevs::Bag #bagmux)]
             pub struct #ident #impl_generics #where_clause {
-                #(pub #ports_ident: #ports_ty,)*
+                #(#ports_vis #ports_ident: #ports_ty,)*
             }
             impl #impl_generics #ident #ty_generics #where_clause {
                 #[inline]

--- a/macros/src/component/state.rs
+++ b/macros/src/component/state.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream as TokenStream2;
-use syn::{Generics, Ident, Type};
+use syn::{Generics, Ident, Type, Visibility};
 
 use super::ComponentField;
 
@@ -31,7 +31,7 @@ impl State {
         self.fields.iter().map(|f| &f.ty).collect()
     }
 
-    pub fn quote(&self) -> TokenStream2 {
+    pub fn quote(&self, vis: &Visibility) -> TokenStream2 {
         let ident = &self.ident;
         let fields_vis = self.field_vis();
         let fields_ident = self.field_idents();
@@ -40,7 +40,7 @@ impl State {
 
         // TODO determine what to do with state struct visibility
         quote::quote! {
-            pub struct #ident #impl_generics #where_clause {
+            #vis struct #ident #impl_generics #where_clause {
                 #(#fields_vis #fields_ident: #fields_ty,)*
             }
             impl #impl_generics #ident #ty_generics #where_clause {

--- a/macros/src/component/state.rs
+++ b/macros/src/component/state.rs
@@ -19,6 +19,10 @@ impl State {
         }
     }
 
+    pub fn field_vis(&self) -> Vec<&syn::Visibility> {
+        self.fields.iter().map(|f| &f.vis).collect()
+    }
+
     pub fn field_idents(&self) -> Vec<&Ident> {
         self.fields.iter().map(|f| &f.ident).collect()
     }
@@ -29,13 +33,15 @@ impl State {
 
     pub fn quote(&self) -> TokenStream2 {
         let ident = &self.ident;
+        let fields_vis = self.field_vis();
         let fields_ident = self.field_idents();
         let fields_ty = self.field_tys();
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
 
+        // TODO determine what to do with state struct visibility
         quote::quote! {
             pub struct #ident #impl_generics #where_clause {
-                #(#fields_ident: #fields_ty,)*
+                #(#fields_vis #fields_ident: #fields_ty,)*
             }
             impl #impl_generics #ident #ty_generics #where_clause {
                 #[inline]


### PR DESCRIPTION
Now that we have the new parsing for the #[xdevs::atomic] and #[xdevs::coupled], we can start applying the new fields to adjust the visibility of the generated code. We can also reduce the length of paths when retrieving variables in the quote methods of both macros.