### PR TITLE
Component: move timing methods to SimTime trait

### DIFF
--- a/macros/src/component.rs
+++ b/macros/src/component.rs
@@ -335,6 +335,14 @@ fn impl_component(
         unsafe impl #impl_generics xdevs::traits::Component for #ident #ty_generics{
             type Input = #input_ident #input_generics;
             type Output = #output_ident #output_generics;
+        }
+    }
+}
+
+fn impl_sim_time(ident: &Ident, generics: &Generics) -> TokenStream2 {
+    let (impl_generics, ty_generics, _) = generics.split_for_impl();
+    quote::quote! {
+        unsafe impl #impl_generics xdevs::traits::SimTime for #ident #ty_generics{
             #[inline]
             fn get_t_last(&self) -> f64 {
                 self.t_last

--- a/macros/src/component.rs
+++ b/macros/src/component.rs
@@ -332,7 +332,7 @@ fn impl_component(
 ) -> TokenStream2 {
     let (impl_generics, ty_generics, _) = generics.split_for_impl();
     quote::quote! {
-        unsafe impl #impl_generics xdevs::traits::Component for #ident #ty_generics{
+        impl #impl_generics xdevs::traits::Component for #ident #ty_generics{
             type Input = #input_ident #input_generics;
             type Output = #output_ident #output_generics;
         }

--- a/macros/src/component/atomic.rs
+++ b/macros/src/component/atomic.rs
@@ -1,8 +1,6 @@
 use crate::combine_err;
-use crate::component::ComponentArgs;
 
-use super::impl_component;
-use super::Component;
+use super::{impl_component, impl_sim_time, Component, ComponentArgs};
 use proc_macro2::TokenStream as TokenStream2;
 use syn::{Error, ItemStruct, Result};
 
@@ -88,6 +86,9 @@ impl Atomic {
             &output_generics,
         );
 
+        // SimTime trait implementation
+        let sim_time_impl = impl_sim_time(ident, &component.generics);
+
         // Generate the expanded code
         let expanded = quote::quote! {
             #input_struct
@@ -110,6 +111,7 @@ impl Atomic {
                 }
             }
             #component_impl
+            #sim_time_impl
             unsafe impl #impl_generics ::xdevs::traits::PartialAtomic for #ident #ty_generics #where_clause {
                 type State = #state_ident #state_generics;
             }
@@ -117,11 +119,11 @@ impl Atomic {
                 #[inline]
                 fn start(&mut self, t_start: f64) -> f64 {
                     // set t_last to t_start
-                    ::xdevs::traits::Component::set_t_last(self, t_start);
+                    ::xdevs::traits::SimTime::set_t_last(self, t_start);
                     // start state and get t_next from ta
                     <Self as ::xdevs::Atomic>::start(&mut self.state);
                     let t_next = t_start + <Self as ::xdevs::Atomic>::ta(&self.state);
-                    ::xdevs::traits::Component::set_t_next(self, t_next);
+                    ::xdevs::traits::SimTime::set_t_next(self, t_next);
 
                     t_next
                 }
@@ -130,19 +132,19 @@ impl Atomic {
                     // stop state
                     <Self as ::xdevs::Atomic>::stop(&mut self.state);
                     // set t_last to t_stop and t_next to infinity
-                    ::xdevs::traits::Component::set_t_last(self, t_stop);
-                    ::xdevs::traits::Component::set_t_next(self, f64::INFINITY);
+                    ::xdevs::traits::SimTime::set_t_last(self, t_stop);
+                    ::xdevs::traits::SimTime::set_t_next(self, f64::INFINITY);
                 }
                 #[inline]
                 fn lambda(&mut self, output: &mut Self::Output, t: f64) {
-                    if t >= ::xdevs::traits::Component::get_t_next(self) {
+                    if t >= ::xdevs::traits::SimTime::get_t_next(self) {
                         // execute atomic model's lambda if applies
                         <Self as ::xdevs::Atomic>::lambda(&self.state, output);
                     }
                 }
                 #[inline]
                 fn delta(&mut self, input: &mut Self::Input, output: &mut Self::Output, t: f64) -> f64 {
-                    let mut t_next = ::xdevs::traits::Component::get_t_next(self);
+                    let mut t_next = ::xdevs::traits::SimTime::get_t_next(self);
                     if !::xdevs::traits::Bag::is_empty(input) {
                         if t >= t_next {
                             // confluent transition
@@ -151,7 +153,7 @@ impl Atomic {
                             <Self::Output as ::xdevs::traits::Bag>::clear(output);
                         } else {
                             // external transition
-                            let e = t - ::xdevs::traits::Component::get_t_last(self);
+                            let e = t - ::xdevs::traits::SimTime::get_t_last(self);
                             <Self as ::xdevs::Atomic>::delta_ext(&mut self.state, e, input);
                         }
                         // clear input events
@@ -166,8 +168,8 @@ impl Atomic {
                     }
                     // get t_next from ta and set new t_last and t_next
                     t_next = t + <Self as ::xdevs::Atomic>::ta(&self.state);
-                    ::xdevs::traits::Component::set_t_last(self, t);
-                    ::xdevs::traits::Component::set_t_next(self, t_next);
+                    ::xdevs::traits::SimTime::set_t_last(self, t);
+                    ::xdevs::traits::SimTime::set_t_next(self, t_next);
 
                     t_next
                 }

--- a/macros/src/component/coupled.rs
+++ b/macros/src/component/coupled.rs
@@ -1,10 +1,7 @@
 pub mod components;
 
+use super::{impl_component, impl_sim_time, Component, ComponentArgs};
 use crate::combine_err;
-use crate::component::ComponentArgs;
-
-use super::impl_component;
-use super::Component;
 use proc_macro2::TokenStream as TokenStream2;
 use syn::{Error, Ident, ItemStruct, Result};
 
@@ -87,6 +84,9 @@ impl Coupled {
             &output_ty_generics,
         );
 
+        // SimTime trait implementation
+        let sim_time_impl = impl_sim_time(ident, &component.generics);
+
         // Generate rt_engine code if defined
         let rt_engine_impl = component.quote_rt_engine();
 
@@ -160,6 +160,7 @@ impl Coupled {
                 }
             }
             #component_impl
+            #sim_time_impl
             unsafe impl #impl_generics ::xdevs::traits::PartialCoupled for #ident #ty_generics #where_clause {
                 type ComponentsInput = #components_input_ident #components_ty_generics;
                 type ComponentsOutput = #components_output_ident #components_ty_generics;
@@ -168,12 +169,12 @@ impl Coupled {
                 #[inline]
                 fn start(&mut self, t_start: f64) -> f64 {
                     // set t_last to t_start
-                    ::xdevs::traits::Component::set_t_last(self, t_start);
+                    ::xdevs::traits::SimTime::set_t_last(self, t_start);
                     // get minimum t_next from all components
                     let mut t_next = f64::INFINITY;
                     #(t_next = f64::min(t_next, ::xdevs::traits::AbstractSimulator::start(&mut self.components.#components_fields, t_start));)*
                     // set t_next to minimum t_next
-                    ::xdevs::traits::Component::set_t_next(self, t_next);
+                    ::xdevs::traits::SimTime::set_t_next(self, t_next);
 
                     t_next
                 }
@@ -183,13 +184,13 @@ impl Coupled {
                     // stop all components
                     #(::xdevs::traits::AbstractSimulator::stop(&mut self.components.#components_fields, t_stop);)*
                     // set t_last to t_stop and t_next to infinity
-                    ::xdevs::traits::Component::set_t_last(self, t_stop);
-                    ::xdevs::traits::Component::set_t_next(self, f64::INFINITY);
+                    ::xdevs::traits::SimTime::set_t_last(self, t_stop);
+                    ::xdevs::traits::SimTime::set_t_next(self, f64::INFINITY);
                 }
 
                 #[inline]
                 fn lambda(&mut self, output: &mut Self::Output, t: f64) {
-                    if t >= ::xdevs::traits::Component::get_t_next(self) {
+                    if t >= ::xdevs::traits::SimTime::get_t_next(self) {
                         // propagate lambda to all components
                         #(::xdevs::traits::AbstractSimulator::lambda(&mut self.components.#components_fields, &mut self.components_output.#components_fields, t);)*
                         // propagate EOCs via Coupled trait
@@ -212,8 +213,8 @@ impl Coupled {
                          t));)*
 
                     // set t_last to t and t_next to minimum t_next
-                    ::xdevs::traits::Component::set_t_last(self, t);
-                    ::xdevs::traits::Component::set_t_next(self, t_next);
+                    ::xdevs::traits::SimTime::set_t_last(self, t);
+                    ::xdevs::traits::SimTime::set_t_next(self, t_next);
 
                     // clear input and output events
                     <Self::Input as ::xdevs::traits::Bag>::clear(input);

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -25,7 +25,7 @@ impl<T: AsPort, const N: usize> AsPort for [T; N] {
 
 impl<T: AsPort, const N: usize> Sealed for [T; N] {}
 
-unsafe impl<T: Component, const N: usize> Component for [T; N] {
+impl<T: Component, const N: usize> Component for [T; N] {
     type Input = [T::Input; N];
     type Output = [T::Output; N];
 }
@@ -87,7 +87,7 @@ unsafe impl<T: AbstractSimulator, const N: usize> AbstractSimulator for [T; N] {
 
 macro_rules! impl_ref {
     ( $ty:ty ) => {
-        unsafe impl<T: Component> Component for $ty {
+        impl<T: Component> Component for $ty {
             type Input = T::Input;
             type Output = T::Output;
         }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -2,11 +2,7 @@
 #[cfg(any(feature = "std", feature = "alloc"))]
 extern crate alloc;
 
-use crate::traits::sealed::Sealed;
-use crate::traits::AbstractSimulator;
-use crate::traits::AsPort;
-use crate::traits::Bag;
-use crate::traits::Component;
+use crate::traits::{sealed::Sealed, AbstractSimulator, AsPort, Bag, Component, SimTime};
 
 //////////////////////////////////////////////// Arrays //////////////////////////////////////////////
 unsafe impl<T: Bag, const N: usize> Bag for [T; N] {
@@ -32,7 +28,9 @@ impl<T: AsPort, const N: usize> Sealed for [T; N] {}
 unsafe impl<T: Component, const N: usize> Component for [T; N] {
     type Input = [T::Input; N];
     type Output = [T::Output; N];
+}
 
+unsafe impl<T: SimTime, const N: usize> SimTime for [T; N] {
     fn get_t_last(&self) -> f64 {
         self.iter()
             .map(|c| c.get_t_last())
@@ -92,7 +90,9 @@ macro_rules! impl_ref {
         unsafe impl<T: Component> Component for $ty {
             type Input = T::Input;
             type Output = T::Output;
+        }
 
+        unsafe impl<T: SimTime> SimTime for $ty {
             fn get_t_last(&self) -> f64 {
                 (**self).get_t_last()
             }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -61,18 +61,6 @@ pub unsafe trait Component {
 
     /// Output event bag of the model.
     type Output: Bag;
-
-    /// Returns the last time the component was updated.
-    fn get_t_last(&self) -> f64;
-
-    /// Sets the last time the component was updated.
-    fn set_t_last(&mut self, t_last: f64);
-
-    /// Returns the next time the component will be updated.
-    fn get_t_next(&self) -> f64;
-
-    /// Sets the next time the component will be updated.
-    fn set_t_next(&mut self, t_next: f64);
 }
 
 /// Partial interface for DEVS atomic models.
@@ -100,12 +88,34 @@ pub unsafe trait PartialCoupled: Component {
     type ComponentsOutput: Bag;
 }
 
+/// Trait for handling time during a DEVS simulation.
+///
+/// In order to be able to simulate DEVS models, the simulator needs this trait to
+/// keep track of time and the time of the next state transition of each component.
+///
+/// # Safety
+///
+/// This trait must be implemented via macros. Do not implement it manually.
+pub unsafe trait SimTime {
+    /// Returns the last time the component was updated.
+    fn get_t_last(&self) -> f64;
+
+    /// Sets the last time the component was updated.
+    fn set_t_last(&mut self, t_last: f64);
+
+    /// Returns the next time the component will be updated.
+    fn get_t_next(&self) -> f64;
+
+    /// Sets the next time the component will be updated.
+    fn set_t_next(&mut self, t_next: f64);
+}
+
 /// Interface for simulating DEVS models. All DEVS models must implement this trait.
 ///
 /// # Safety
 ///
 /// This trait must be implemented via macros. Do not implement it manually.
-pub unsafe trait AbstractSimulator: Component {
+pub unsafe trait AbstractSimulator: Component + SimTime {
     /// It starts the simulation, setting the initial time to t_start.
     /// It returns the time for the next state transition of the inner DEVS model.
     fn start(&mut self, t_start: f64) -> f64;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -51,11 +51,7 @@ pub unsafe trait BagMux: Bag {
 }
 
 /// Interface for DEVS components. All DEVS components must implement this trait.
-///
-/// # Safety
-///
-/// This trait must be implemented via macros. Do not implement it manually.
-pub unsafe trait Component {
+pub trait Component {
     /// Input event bag of the model.
     type Input: Bag;
 


### PR DESCRIPTION
Closes #30 

I explored using a time struct, but it does not help with things like model arrays. Therefore, I think it is better to just split the current Component trait into Component (only input and output) and SimTime (simulation time-related methods)

@dmunizu check this PR out. It should be OK to merge, as it has no practical difference with the current state of the crate.