### PR TITLE
Enum macro and reduce DEVStone size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,10 @@ name = "gpt_async"
 required-features = ["std"]
 
 [[example]]
+name = "gpt_enum"
+required-features = ["std"]
+
+[[example]]
 name = "gpt"
 required-features = ["std"]
 

--- a/examples/gpt_enum.rs
+++ b/examples/gpt_enum.rs
@@ -1,4 +1,4 @@
-/// Illustrates #[xdevs::modelenum]: a GPT model where the processor is
+/// Illustrates #[xdevs::model_enum]: a GPT model where the processor is
 /// chosen at build time between a fast and a slow variant, without any
 /// conditional logic in the coupled model.
 use xdevs::simulation::Simulable;
@@ -92,10 +92,10 @@ mod processor {
     }
 
     impl FastProcessor {
-        pub fn new() -> Self {
+        pub fn new(time: f64) -> Self {
             Self {
-                sigma: f64::INFINITY,
-                time: 0.5,
+                sigma: 0.0,
+                time,
                 job: None,
             }
         }
@@ -135,23 +135,23 @@ mod processor {
                 if self.job.is_none() {
                     println!("[P-slow] received job {}", job);
                     self.job = Some(job);
-                    self.sigma = self.time;
+                    self.sigma = self.time * 2.0; // Slow processor takes twice as long
                 }
             }
         }
     }
 
     impl SlowProcessor {
-        pub fn new() -> Self {
+        pub fn new(time: f64) -> Self {
             Self {
-                sigma: f64::INFINITY,
-                time: 2.0,
+                sigma: 0.0,
+                time,
                 job: None,
             }
         }
     }
 
-    #[xdevs::modelenum]
+    #[xdevs::model_enum]
     pub enum Processor {
         Fast(FastProcessor),
         Slow(SlowProcessor),
@@ -251,15 +251,18 @@ impl xdevs::Coupled for GPT {
 }
 
 fn run_gpt(processor: processor::Processor) {
+    let period = 1.;
+    let obs_time = 10.;
+
     let label = match &processor {
         processor::Processor::Fast(_) => "fast",
         processor::Processor::Slow(_) => "slow",
     };
     println!("\n--- GPT with {} processor ---", label);
     let gpt = GPT::build(
-        generator::Generator::new(1.0),
+        generator::Generator::new(period),
         processor,
-        transducer::Transducer::new(10.0),
+        transducer::Transducer::new(obs_time),
     );
     let mut simulator = gpt.to_simulator();
     let config = xdevs::simulation::Config::new(0.0, 14.0, 1.0, None);
@@ -267,9 +270,10 @@ fn run_gpt(processor: processor::Processor) {
 }
 
 fn main() {
-    let fast = processor::Processor::Fast(processor::FastProcessor::new().to_simulator());
+    let proc_time = 1.1;
+    let fast = processor::Processor::Fast(processor::FastProcessor::new(proc_time).to_simulator());
     run_gpt(fast);
 
-    let slow = processor::Processor::Slow(processor::SlowProcessor::new().to_simulator());
+    let slow = processor::Processor::Slow(processor::SlowProcessor::new(proc_time).to_simulator());
     run_gpt(slow);
 }

--- a/examples/gpt_enum.rs
+++ b/examples/gpt_enum.rs
@@ -1,0 +1,275 @@
+/// Illustrates #[xdevs::modelenum]: a GPT model where the processor is
+/// chosen at build time between a fast and a slow variant, without any
+/// conditional logic in the coupled model.
+use xdevs::simulation::Simulable;
+use xdevs::AbstractSimulator;
+
+mod generator {
+    pub struct Generator {
+        sigma: f64,
+        period: f64,
+        count: usize,
+    }
+
+    impl xdevs::Component for Generator {
+        type Kind = xdevs::AtomicKind;
+        type Input = xdevs::Port<bool, 1>;
+        type Output = xdevs::Port<usize, 1>;
+    }
+
+    impl xdevs::Atomic for Generator {
+        fn delta_int(&mut self) {
+            self.count += 1;
+            self.sigma = self.period;
+            println!("[G] generated job {}", self.count);
+        }
+        fn lambda(&self, output: &mut Self::Output) {
+            output.add_value(self.count).unwrap();
+        }
+        fn ta(&self) -> f64 {
+            self.sigma
+        }
+        fn delta_ext(&mut self, elapsed: f64, input: &Self::Input) {
+            self.sigma -= elapsed;
+            if let Some(&stop) = input.get_values().last() {
+                if stop {
+                    self.sigma = f64::INFINITY;
+                }
+            }
+        }
+    }
+
+    impl Generator {
+        pub fn new(period: f64) -> Self {
+            Self {
+                sigma: 0.0,
+                period,
+                count: 0,
+            }
+        }
+    }
+}
+
+mod processor {
+    pub struct FastProcessor {
+        sigma: f64,
+        time: f64,
+        job: Option<usize>,
+    }
+
+    impl xdevs::Component for FastProcessor {
+        type Kind = xdevs::AtomicKind;
+        type Input = xdevs::Port<usize, 1>;
+        type Output = xdevs::Port<usize, 1>;
+    }
+
+    impl xdevs::Atomic for FastProcessor {
+        fn delta_int(&mut self) {
+            self.sigma = f64::INFINITY;
+            if let Some(job) = self.job {
+                println!("[P-fast] processed job {}", job);
+            }
+            self.job = None;
+        }
+        fn lambda(&self, output: &mut Self::Output) {
+            if let Some(job) = self.job {
+                output.add_value(job).unwrap();
+            }
+        }
+        fn ta(&self) -> f64 {
+            self.sigma
+        }
+        fn delta_ext(&mut self, elapsed: f64, input: &Self::Input) {
+            self.sigma -= elapsed;
+            if let Some(&job) = input.get_values().last() {
+                if self.job.is_none() {
+                    println!("[P-fast] received job {}", job);
+                    self.job = Some(job);
+                    self.sigma = self.time;
+                }
+            }
+        }
+    }
+
+    impl FastProcessor {
+        pub fn new() -> Self {
+            Self {
+                sigma: f64::INFINITY,
+                time: 0.5,
+                job: None,
+            }
+        }
+    }
+
+    pub struct SlowProcessor {
+        sigma: f64,
+        time: f64,
+        job: Option<usize>,
+    }
+
+    impl xdevs::Component for SlowProcessor {
+        type Kind = xdevs::AtomicKind;
+        type Input = xdevs::Port<usize, 1>;
+        type Output = xdevs::Port<usize, 1>;
+    }
+
+    impl xdevs::Atomic for SlowProcessor {
+        fn delta_int(&mut self) {
+            self.sigma = f64::INFINITY;
+            if let Some(job) = self.job {
+                println!("[P-slow] processed job {}", job);
+            }
+            self.job = None;
+        }
+        fn lambda(&self, output: &mut Self::Output) {
+            if let Some(job) = self.job {
+                output.add_value(job).unwrap();
+            }
+        }
+        fn ta(&self) -> f64 {
+            self.sigma
+        }
+        fn delta_ext(&mut self, elapsed: f64, input: &Self::Input) {
+            self.sigma -= elapsed;
+            if let Some(&job) = input.get_values().last() {
+                if self.job.is_none() {
+                    println!("[P-slow] received job {}", job);
+                    self.job = Some(job);
+                    self.sigma = self.time;
+                }
+            }
+        }
+    }
+
+    impl SlowProcessor {
+        pub fn new() -> Self {
+            Self {
+                sigma: f64::INFINITY,
+                time: 2.0,
+                job: None,
+            }
+        }
+    }
+
+    #[xdevs::modelenum]
+    pub enum Processor {
+        Fast(FastProcessor),
+        Slow(SlowProcessor),
+    }
+}
+
+mod transducer {
+    #[derive(xdevs::Bag)]
+    pub struct TransducerInput {
+        pub in_generator: xdevs::Port<usize, 1>,
+        pub in_processor: xdevs::Port<usize, 1>,
+    }
+
+    pub struct Transducer {
+        sigma: f64,
+        clock: f64,
+        n_generated: usize,
+        n_processed: usize,
+    }
+
+    impl xdevs::Component for Transducer {
+        type Kind = xdevs::AtomicKind;
+        type Input = TransducerInput;
+        type Output = xdevs::Port<bool, 1>;
+    }
+
+    impl xdevs::Atomic for Transducer {
+        fn delta_int(&mut self) {
+            self.clock += self.sigma;
+            let (acceptance, throughput) = if self.n_processed > 0 {
+                (
+                    self.n_processed as f64 / self.n_generated as f64,
+                    self.n_processed as f64 / self.clock,
+                )
+            } else {
+                (0.0, 0.0)
+            };
+            println!(
+                "[T] acceptance: {:.2}, throughput: {:.2} jobs/s",
+                acceptance, throughput
+            );
+            self.sigma = f64::INFINITY;
+        }
+        fn lambda(&self, output: &mut Self::Output) {
+            output.add_value(true).unwrap();
+        }
+        fn ta(&self) -> f64 {
+            self.sigma
+        }
+        fn delta_ext(&mut self, elapsed: f64, input: &Self::Input) {
+            self.sigma -= elapsed;
+            self.clock += elapsed;
+            self.n_generated += input.in_generator.get_values().len();
+            self.n_processed += input.in_processor.get_values().len();
+        }
+    }
+
+    impl Transducer {
+        pub fn new(obs_time: f64) -> Self {
+            Self {
+                sigma: obs_time,
+                clock: 0.0,
+                n_generated: 0,
+                n_processed: 0,
+            }
+        }
+    }
+}
+
+#[xdevs::coupled]
+pub struct GPT {
+    generator: generator::Generator,
+    processor: processor::Processor,
+    transducer: transducer::Transducer,
+}
+
+impl xdevs::Component for GPT {
+    type Kind = xdevs::CoupledKind;
+    type Input = ();
+    type Output = ();
+}
+
+impl xdevs::Coupled for GPT {
+    fn ic(
+        from: &xdevs::component::coupled::ComponentsOutput<Self>,
+        to: &mut xdevs::component::coupled::ComponentsInput<Self>,
+    ) {
+        from.generator.couple(&mut to.processor).unwrap();
+        from.processor
+            .couple(&mut to.transducer.in_processor)
+            .unwrap();
+        from.generator
+            .couple(&mut to.transducer.in_generator)
+            .unwrap();
+        from.transducer.couple(&mut to.generator).unwrap();
+    }
+}
+
+fn run_gpt(processor: processor::Processor) {
+    let label = match &processor {
+        processor::Processor::Fast(_) => "fast",
+        processor::Processor::Slow(_) => "slow",
+    };
+    println!("\n--- GPT with {} processor ---", label);
+    let gpt = GPT::build(
+        generator::Generator::new(1.0),
+        processor,
+        transducer::Transducer::new(10.0),
+    );
+    let mut simulator = gpt.to_simulator();
+    let config = xdevs::simulation::Config::new(0.0, 14.0, 1.0, None);
+    simulator.simulate_rt(&config, xdevs::simulation::std::sleep(&config), |_| {});
+}
+
+fn main() {
+    let fast = processor::Processor::Fast(processor::FastProcessor::new().to_simulator());
+    run_gpt(fast);
+
+    let slow = processor::Processor::Slow(processor::SlowProcessor::new().to_simulator());
+    run_gpt(slow);
+}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -4,8 +4,8 @@ use syn::{parse, parse_macro_input, Error};
 mod coupled;
 mod derive;
 mod devstone;
-mod rt_engine;
 mod modelenum;
+mod rt_engine;
 
 // Main macro to generate coupled DEVS models
 #[proc_macro_attribute]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -5,6 +5,7 @@ mod coupled;
 mod derive;
 mod devstone;
 mod rt_engine;
+mod modelenum;
 
 // Main macro to generate coupled DEVS models
 #[proc_macro_attribute]
@@ -12,6 +13,17 @@ pub fn coupled(_args: TokenStream, item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as syn::ItemStruct);
 
     match coupled::expand(item) {
+        Ok(component) => component.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+// Macro to generate enum-based DEVS components
+#[proc_macro_attribute]
+pub fn modelenum(_args: TokenStream, item: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(item as syn::ItemEnum);
+
+    match modelenum::expand(item) {
         Ok(component) => component.into(),
         Err(err) => err.to_compile_error().into(),
     }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -4,10 +4,10 @@ use syn::{parse, parse_macro_input, Error};
 mod coupled;
 mod derive;
 mod devstone;
-mod modelenum;
+mod model_enum;
 mod rt_engine;
 
-// Main macro to generate coupled DEVS models
+/// Main macro to generate coupled DEVS models
 #[proc_macro_attribute]
 pub fn coupled(_args: TokenStream, item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as syn::ItemStruct);
@@ -18,18 +18,18 @@ pub fn coupled(_args: TokenStream, item: TokenStream) -> TokenStream {
     }
 }
 
-// Macro to generate enum-based DEVS components
+/// Macro to generate enum-based DEVS components
 #[proc_macro_attribute]
-pub fn modelenum(_args: TokenStream, item: TokenStream) -> TokenStream {
+pub fn model_enum(_args: TokenStream, item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as syn::ItemEnum);
 
-    match modelenum::expand(item) {
+    match model_enum::expand(item) {
         Ok(component) => component.into(),
         Err(err) => err.to_compile_error().into(),
     }
 }
 
-// Macro to generate RT engine components
+/// Macro to generate RT engine components
 #[proc_macro_attribute]
 pub fn rt_engine(args: TokenStream, item: TokenStream) -> TokenStream {
     let args = match parse::<rt_engine::RtEngineArgs>(args) {
@@ -70,7 +70,7 @@ pub fn derive_bagmux(input: TokenStream) -> TokenStream {
     }
 }
 
-/// Function to combine errors when parsing
+// Function to combine errors when parsing
 pub(crate) fn combine_err(acc: &mut Option<Error>, err: Error) {
     match acc {
         Some(e) => e.combine(err),
@@ -78,7 +78,7 @@ pub(crate) fn combine_err(acc: &mut Option<Error>, err: Error) {
     }
 }
 
-// DEVStone macros — ref version (default, no alloc needed)
+/// DEVStone macros — ref version (default, no alloc needed)
 #[proc_macro]
 pub fn generate_li(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as devstone::GenerateArgs);
@@ -109,7 +109,7 @@ pub fn generate_ho(input: TokenStream) -> TokenStream {
     }
 }
 
-// DEVStone macros — box version (needs alloc feature)
+/// DEVStone macros — box version (needs alloc feature)
 #[proc_macro]
 pub fn generate_li_box(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as devstone::GenerateArgs);

--- a/macros/src/model_enum.rs
+++ b/macros/src/model_enum.rs
@@ -44,8 +44,14 @@ pub fn expand(mut item: ItemEnum) -> Result<TokenStream2> {
         return Err(err);
     }
 
-    let first_variant_ty = &variant_tys[0];
+    if variant_tys.is_empty() {
+        return Err(Error::new_spanned(
+            &item.ident,
+            "enum component must have at least one variant",
+        ));
+    }
 
+    let first_variant_ty = &variant_tys[0];
     for variant in item.variants.iter_mut() {
         if let syn::Fields::Unnamed(fields) = &mut variant.fields {
             if let Some(field) = fields.unnamed.first_mut() {

--- a/macros/src/modelenum.rs
+++ b/macros/src/modelenum.rs
@@ -1,0 +1,128 @@
+use crate::combine_err;
+use proc_macro2::TokenStream as TokenStream2;
+use syn::{Error, ItemEnum, Result};
+
+pub fn expand(mut item: ItemEnum) -> Result<TokenStream2> {
+    let mut acc: Option<Error> = None;
+
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+    let item_ident = &item.ident;
+
+    let mut variant_idents = Vec::new();
+    let mut variant_tys = Vec::new();
+
+    for variant in &item.variants {
+        let fields = &variant.fields;
+        match fields {
+            syn::Fields::Unnamed(fields) => {
+                if fields.unnamed.len() != 1 {
+                    combine_err(
+                        &mut acc,
+                        Error::new_spanned(
+                            &variant,
+                            "enum variant must have exactly one type parameter",
+                        ),
+                    );
+                    continue;
+                }
+                variant_idents.push(variant.ident.clone());
+                variant_tys.push(fields.unnamed.first().unwrap().ty.clone());
+            }
+            _ => {
+                combine_err(
+                    &mut acc,
+                    Error::new_spanned(
+                        &variant,
+                        "only tuple variants with a single type are supported for enum components",
+                    ),
+                );
+            }
+        }
+    }
+
+    if let Some(err) = acc {
+        return Err(err);
+    }
+
+    let first_variant_ty = &variant_tys[0];
+
+    for variant in item.variants.iter_mut() {
+        if let syn::Fields::Unnamed(fields) = &mut variant.fields {
+            if let Some(field) = fields.unnamed.first_mut() {
+                let ty = &field.ty;
+                field.ty = syn::parse_quote! {
+                    <#ty as ::xdevs::simulation::SimpleSimulable>::Simulator
+                };
+            }
+        }
+    }
+
+    let start_arms = variant_idents.iter().map(|ident| {
+        quote::quote! {
+            #item_ident::#ident(inner) => ::xdevs::simulation::AbstractSimulator::start(inner, t_start)
+        }
+    });
+
+    let stop_arms = variant_idents.iter().map(|ident| {
+        quote::quote! {
+            #item_ident::#ident(inner) => ::xdevs::simulation::AbstractSimulator::stop(inner)
+        }
+    });
+
+    let lambda_arms = variant_idents.iter().map(|ident| {
+        quote::quote! {
+            #item_ident::#ident(inner) => ::xdevs::simulation::AbstractSimulator::lambda(inner, output, t)
+        }
+    });
+
+    let delta_arms = variant_idents.iter().map(|ident| {
+        quote::quote! {
+            #item_ident::#ident(inner) => ::xdevs::simulation::AbstractSimulator::delta(inner, input, output, t)
+        }
+    });
+
+    let expanded = quote::quote! {
+        #item
+
+        impl #impl_generics ::xdevs::Component for #item_ident #ty_generics #where_clause {
+            type Kind = ::xdevs::ComponentsKind;
+            type Input = <#first_variant_ty as ::xdevs::Component>::Input;
+            type Output = <#first_variant_ty as ::xdevs::Component>::Output;
+        }
+
+        unsafe impl #impl_generics ::xdevs::simulation::AbstractSimulator for #item_ident #ty_generics #where_clause {
+            type Input = <#first_variant_ty as ::xdevs::Component>::Input;
+            type Output = <#first_variant_ty as ::xdevs::Component>::Output;
+
+            #[inline(always)]
+            fn start(&mut self, t_start: f64) -> f64 {
+                match self {
+                    #(#start_arms),*
+                }
+            }
+
+            #[inline(always)]
+            fn stop(&mut self) {
+                match self {
+                    #(#stop_arms),*
+                }
+            }
+
+            #[inline(always)]
+            fn lambda(&mut self, output: &mut Self::Output, t: f64) {
+                match self {
+                    #(#lambda_arms),*
+                }
+            }
+
+            #[inline(always)]
+            fn delta(&mut self, input: &mut Self::Input, output: &mut Self::Output, t: f64) -> f64 {
+                match self {
+                    #(#delta_arms),*
+                }
+            }
+        }
+    };
+
+    Ok(expanded)
+}

--- a/src/devstone/common.rs
+++ b/src/devstone/common.rs
@@ -87,20 +87,29 @@ impl AtomicModel {
             n_events: 0,
         }
     }
+}
 
-    pub fn get_n_internals(&self) -> usize {
+pub trait Devstone {
+    fn get_n_internals(&self) -> usize;
+    fn get_n_externals(&self) -> usize;
+    fn get_n_events(&self) -> usize;
+    fn get_n_atomics(&self) -> usize;
+}
+
+impl Devstone for AtomicModel {
+    fn get_n_internals(&self) -> usize {
         self.n_internals
     }
 
-    pub fn get_n_externals(&self) -> usize {
+    fn get_n_externals(&self) -> usize {
         self.n_externals
     }
 
-    pub fn get_n_events(&self) -> usize {
+    fn get_n_events(&self) -> usize {
         self.n_events
     }
 
-    pub fn get_n_atomics(&self) -> usize {
+    fn get_n_atomics(&self) -> usize {
         1
     }
 }
@@ -121,20 +130,22 @@ impl LeafModel {
     pub fn new() -> Self {
         Self::build(AtomicModel::new())
     }
+}
 
-    pub fn get_n_internals(&self) -> usize {
+impl Devstone for LeafModel {
+    fn get_n_internals(&self) -> usize {
         self.components.atomic.get_n_internals()
     }
 
-    pub fn get_n_externals(&self) -> usize {
+    fn get_n_externals(&self) -> usize {
         self.components.atomic.get_n_externals()
     }
 
-    pub fn get_n_events(&self) -> usize {
+    fn get_n_events(&self) -> usize {
         self.components.atomic.get_n_events()
     }
 
-    pub fn get_n_atomics(&self) -> usize {
+    fn get_n_atomics(&self) -> usize {
         self.components.atomic.get_n_atomics()
     }
 }
@@ -152,6 +163,106 @@ impl xdevs::Coupled for LeafModel {
     fn eoc(from: &<Self::Components as xdevs::Component>::Output, to: &mut Self::Output) {
         let _ = from.atomic.couple(to);
     }
+}
+
+#[macro_export]
+macro_rules! impl_devstone_leaf {
+    () => {
+        fn get_n_internals(&self) -> usize {
+            self.components.atomic.get_n_internals()
+        }
+        fn get_n_externals(&self) -> usize {
+            self.components.atomic.get_n_externals()
+        }
+        fn get_n_events(&self) -> usize {
+            self.components.atomic.get_n_events()
+        }
+        fn get_n_atomics(&self) -> usize {
+            self.components.atomic.get_n_atomics()
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_devstone_enum {
+    () => {
+        fn get_n_internals(&self) -> usize {
+            match self {
+                Self::Leaf(leaf) => leaf.get_n_internals(),
+                Self::Branch(branch) => branch.get_n_internals(),
+            }
+        }
+        fn get_n_externals(&self) -> usize {
+            match self {
+                Self::Leaf(leaf) => leaf.get_n_externals(),
+                Self::Branch(branch) => branch.get_n_externals(),
+            }
+        }
+        fn get_n_events(&self) -> usize {
+            match self {
+                Self::Leaf(leaf) => leaf.get_n_events(),
+                Self::Branch(branch) => branch.get_n_events(),
+            }
+        }
+        fn get_n_atomics(&self) -> usize {
+            match self {
+                Self::Leaf(leaf) => leaf.get_n_atomics(),
+                Self::Branch(branch) => branch.get_n_atomics(),
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_devstone_coupled {
+    () => {
+        fn get_n_internals(&self) -> usize {
+            let mut sum = self.components.inner.get_n_internals();
+            for a in self.components.atomics.iter() {
+                sum += a.get_n_internals();
+            }
+            sum
+        }
+        fn get_n_externals(&self) -> usize {
+            let mut sum = self.components.inner.get_n_externals();
+            for a in self.components.atomics.iter() {
+                sum += a.get_n_externals();
+            }
+            sum
+        }
+        fn get_n_events(&self) -> usize {
+            let mut sum = self.components.inner.get_n_events();
+            for a in self.components.atomics.iter() {
+                sum += a.get_n_events();
+            }
+            sum
+        }
+        fn get_n_atomics(&self) -> usize {
+            let mut sum = self.components.inner.get_n_atomics();
+            for _ in self.components.atomics.iter() {
+                sum += 1;
+            }
+            sum
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_devstone_top {
+    ($child:ident) => {
+        fn get_n_internals(&self) -> usize {
+            self.components.$child.get_n_internals()
+        }
+        fn get_n_externals(&self) -> usize {
+            self.components.$child.get_n_externals()
+        }
+        fn get_n_events(&self) -> usize {
+            self.components.$child.get_n_events()
+        }
+        fn get_n_atomics(&self) -> usize {
+            self.components.$child.get_n_atomics()
+        }
+    };
 }
 
 #[cfg(test)]

--- a/src/devstone/hi.rs
+++ b/src/devstone/hi.rs
@@ -1,11 +1,12 @@
-use crate::{simulation::coordinator::Coordinator, AbstractSimulator, Component};
+use crate::Component;
 
 use super::common::*;
 
 /// HI model enum (ref version)
+#[crate::modelenum]
 pub enum HIEnum<'a, const W: usize> {
-    Leaf(Coordinator<LeafModel>),
-    Branch(Coordinator<HIModel<'a, W>>),
+    Leaf(LeafModel),
+    Branch(HIModel<'a, W>),
 }
 
 impl<'a, const W: usize> HIEnum<'a, W> {
@@ -34,61 +35,6 @@ impl<'a, const W: usize> HIEnum<'a, W> {
         match self {
             HIEnum::Leaf(leaf) => leaf.get_n_atomics(),
             HIEnum::Branch(branch) => branch.get_n_atomics(),
-        }
-    }
-}
-
-/// Manual implementation of `Component` for HI enum (ref version)
-impl<'a, const W: usize> Component for HIEnum<'a, W> {
-    type Kind = crate::component::ComponentsKind;
-    type Input = crate::Port<usize, 1>;
-    type Output = crate::Port<usize, 1>;
-}
-
-/// Manual implementation of `AbstractSimulator` for HI enum (ref version)
-unsafe impl<'a, const W: usize> AbstractSimulator for HIEnum<'a, W> {
-    type Input = crate::Port<usize, 1>;
-    type Output = crate::Port<usize, 1>;
-
-    fn start(&mut self, t_start: f64) -> f64 {
-        match self {
-            HIEnum::Leaf(leaf) => {
-                <Coordinator<LeafModel> as AbstractSimulator>::start(leaf, t_start)
-            }
-            HIEnum::Branch(branch) => {
-                <Coordinator<HIModel<'a, W>> as AbstractSimulator>::start(branch, t_start)
-            }
-        }
-    }
-
-    fn stop(&mut self) {
-        match self {
-            HIEnum::Leaf(leaf) => <Coordinator<LeafModel> as AbstractSimulator>::stop(leaf),
-            HIEnum::Branch(branch) => {
-                <Coordinator<HIModel<'a, W>> as AbstractSimulator>::stop(branch)
-            }
-        }
-    }
-
-    fn lambda(&mut self, output: &mut Self::Output, t: f64) {
-        match self {
-            HIEnum::Leaf(leaf) => {
-                <Coordinator<LeafModel> as AbstractSimulator>::lambda(leaf, output, t)
-            }
-            HIEnum::Branch(branch) => {
-                <Coordinator<HIModel<'a, W>> as AbstractSimulator>::lambda(branch, output, t)
-            }
-        }
-    }
-
-    fn delta(&mut self, input: &mut Self::Input, output: &mut Self::Output, t: f64) -> f64 {
-        match self {
-            HIEnum::Leaf(leaf) => {
-                <Coordinator<LeafModel> as AbstractSimulator>::delta(leaf, input, output, t)
-            }
-            HIEnum::Branch(branch) => {
-                <Coordinator<HIModel<'a, W>> as AbstractSimulator>::delta(branch, input, output, t)
-            }
         }
     }
 }
@@ -210,6 +156,7 @@ impl<'a, const W: usize> crate::Coupled for TopModel<'a, W> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::simulation::AbstractSimulator;
 
     fn expected_n_atomic(width: usize, depth: usize) -> usize {
         (width - 1) * (depth - 1) + 1

--- a/src/devstone/hi.rs
+++ b/src/devstone/hi.rs
@@ -1,42 +1,15 @@
+use super::common::{AtomicModel, Devstone, JobGenerator, LeafModel};
 use crate::Component;
 
-use super::common::*;
-
 /// HI model enum (ref version)
-#[crate::modelenum]
+#[crate::model_enum]
 pub enum HIEnum<'a, const W: usize> {
     Leaf(LeafModel),
     Branch(HIModel<'a, W>),
 }
 
-impl<'a, const W: usize> HIEnum<'a, W> {
-    pub fn get_n_internals(&self) -> usize {
-        match self {
-            HIEnum::Leaf(leaf) => leaf.get_n_internals(),
-            HIEnum::Branch(branch) => branch.get_n_internals(),
-        }
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        match self {
-            HIEnum::Leaf(leaf) => leaf.get_n_externals(),
-            HIEnum::Branch(branch) => branch.get_n_externals(),
-        }
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        match self {
-            HIEnum::Leaf(leaf) => leaf.get_n_events(),
-            HIEnum::Branch(branch) => branch.get_n_events(),
-        }
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        match self {
-            HIEnum::Leaf(leaf) => leaf.get_n_atomics(),
-            HIEnum::Branch(branch) => branch.get_n_atomics(),
-        }
-    }
+impl<'a, const W: usize> Devstone for HIEnum<'a, W> {
+    crate::impl_devstone_enum!();
 }
 
 /// HI coupled model (ref version)
@@ -79,38 +52,10 @@ impl<'a, const W: usize> HIModel<'a, W> {
     pub fn new(inner: &'a mut HIEnum<'a, W>) -> Self {
         Self::build(core::array::from_fn(|_| AtomicModel::default()), inner)
     }
+}
 
-    pub fn get_n_internals(&self) -> usize {
-        let mut sum_int = self.components.inner.get_n_internals();
-        for atomic in self.components.atomics.iter() {
-            sum_int += atomic.get_n_internals();
-        }
-        sum_int
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        let mut sum_ext = self.components.inner.get_n_externals();
-        for atomic in self.components.atomics.iter() {
-            sum_ext += atomic.get_n_externals();
-        }
-        sum_ext
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        let mut sum_ev = self.components.inner.get_n_events();
-        for atomic in self.components.atomics.iter() {
-            sum_ev += atomic.get_n_events();
-        }
-        sum_ev
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        let mut sum_atomic = self.components.inner.get_n_atomics();
-        for _atomic in self.components.atomics.iter() {
-            sum_atomic += 1;
-        }
-        sum_atomic
-    }
+impl<'a, const W: usize> Devstone for HIModel<'a, W> {
+    crate::impl_devstone_coupled!();
 }
 
 /// End model with Generator and HI model coupled together (ref version)
@@ -126,22 +71,8 @@ impl<'a, const W: usize> Component for TopModel<'a, W> {
     type Output = crate::Port<usize, 1>;
 }
 
-impl<'a, const W: usize> TopModel<'a, W> {
-    pub fn get_n_internals(&self) -> usize {
-        self.components.hi_model.get_n_internals()
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        self.components.hi_model.get_n_externals()
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        self.components.hi_model.get_n_events()
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        self.components.hi_model.get_n_atomics()
-    }
+impl<'a, const W: usize> Devstone for TopModel<'a, W> {
+    crate::impl_devstone_top!(hi_model);
 }
 
 impl<'a, const W: usize> crate::Coupled for TopModel<'a, W> {

--- a/src/devstone/hi_box.rs
+++ b/src/devstone/hi_box.rs
@@ -1,42 +1,16 @@
-use super::common::*;
+use super::common::{AtomicModel, Devstone, JobGenerator, LeafModel};
 use crate::Component;
 use alloc::boxed::Box;
 
 /// HI model enum
-#[xdevs::modelenum]
+#[xdevs::model_enum]
 pub enum HIEnum<const W: usize> {
     Leaf(LeafModel),
     Branch(HIModel<W>),
 }
 
-impl<const W: usize> HIEnum<W> {
-    pub fn get_n_internals(&self) -> usize {
-        match self {
-            HIEnum::Leaf(leaf) => leaf.get_n_internals(),
-            HIEnum::Branch(branch) => branch.get_n_internals(),
-        }
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        match self {
-            HIEnum::Leaf(leaf) => leaf.get_n_externals(),
-            HIEnum::Branch(branch) => branch.get_n_externals(),
-        }
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        match self {
-            HIEnum::Leaf(leaf) => leaf.get_n_events(),
-            HIEnum::Branch(branch) => branch.get_n_events(),
-        }
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        match self {
-            HIEnum::Leaf(leaf) => leaf.get_n_atomics(),
-            HIEnum::Branch(branch) => branch.get_n_atomics(),
-        }
-    }
+impl<const W: usize> Devstone for HIEnum<W> {
+    crate::impl_devstone_enum!();
 }
 
 /// HI coupled model
@@ -79,38 +53,10 @@ impl<const W: usize> HIModel<W> {
     pub fn new(inner: Box<HIEnum<W>>) -> Self {
         Self::build(core::array::from_fn(|_| AtomicModel::default()), inner)
     }
+}
 
-    pub fn get_n_internals(&self) -> usize {
-        let mut sum_int = self.components.inner.get_n_internals();
-        for atomic in self.components.atomics.iter() {
-            sum_int += atomic.get_n_internals();
-        }
-        sum_int
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        let mut sum_ext = self.components.inner.get_n_externals();
-        for atomic in self.components.atomics.iter() {
-            sum_ext += atomic.get_n_externals();
-        }
-        sum_ext
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        let mut sum_ev = self.components.inner.get_n_events();
-        for atomic in self.components.atomics.iter() {
-            sum_ev += atomic.get_n_events();
-        }
-        sum_ev
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        let mut sum_atomic = self.components.inner.get_n_atomics();
-        for _atomic in self.components.atomics.iter() {
-            sum_atomic += 1;
-        }
-        sum_atomic
-    }
+impl<const W: usize> Devstone for HIModel<W> {
+    crate::impl_devstone_coupled!();
 }
 
 /// End model with Generator and HI model coupled together
@@ -125,22 +71,8 @@ impl<const W: usize> Component for TopModel<W> {
     type Input = xdevs::Port<usize, 1>;
     type Output = xdevs::Port<usize, 1>;
 }
-impl<const W: usize> TopModel<W> {
-    pub fn get_n_internals(&self) -> usize {
-        self.components.hi_model.get_n_internals()
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        self.components.hi_model.get_n_externals()
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        self.components.hi_model.get_n_events()
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        self.components.hi_model.get_n_atomics()
-    }
+impl<const W: usize> Devstone for TopModel<W> {
+    crate::impl_devstone_top!(hi_model);
 }
 
 impl<const W: usize> xdevs::Coupled for TopModel<W> {

--- a/src/devstone/hi_box.rs
+++ b/src/devstone/hi_box.rs
@@ -1,11 +1,12 @@
 use super::common::*;
-use crate::{simulation::coordinator::Coordinator, AbstractSimulator, Component};
+use crate::Component;
 use alloc::boxed::Box;
 
 /// HI model enum
+#[xdevs::modelenum]
 pub enum HIEnum<const W: usize> {
-    Leaf(Coordinator<LeafModel>),
-    Branch(Coordinator<HIModel<W>>),
+    Leaf(LeafModel),
+    Branch(HIModel<W>),
 }
 
 impl<const W: usize> HIEnum<W> {
@@ -34,60 +35,6 @@ impl<const W: usize> HIEnum<W> {
         match self {
             HIEnum::Leaf(leaf) => leaf.get_n_atomics(),
             HIEnum::Branch(branch) => branch.get_n_atomics(),
-        }
-    }
-}
-
-/// Manual implementation of `Component` for HI enum
-impl<const W: usize> Component for HIEnum<W> {
-    type Kind = xdevs::component::ComponentsKind;
-    type Input = xdevs::Port<usize, 1>;
-    type Output = xdevs::Port<usize, 1>;
-}
-
-/// Manual implementation of `AbstractSimulator` for HI enum
-unsafe impl<const W: usize> AbstractSimulator for HIEnum<W> {
-    type Input = xdevs::Port<usize, 1>;
-
-    type Output = xdevs::Port<usize, 1>;
-
-    fn start(&mut self, t_start: f64) -> f64 {
-        match self {
-            HIEnum::Leaf(leaf) => {
-                <Coordinator<LeafModel> as AbstractSimulator>::start(leaf, t_start)
-            }
-            HIEnum::Branch(branch) => {
-                <Coordinator<HIModel<W>> as AbstractSimulator>::start(branch, t_start)
-            }
-        }
-    }
-
-    fn stop(&mut self) {
-        match self {
-            HIEnum::Leaf(leaf) => <Coordinator<LeafModel> as AbstractSimulator>::stop(leaf),
-            HIEnum::Branch(branch) => <Coordinator<HIModel<W>> as AbstractSimulator>::stop(branch),
-        }
-    }
-
-    fn lambda(&mut self, output: &mut Self::Output, t: f64) {
-        match self {
-            HIEnum::Leaf(leaf) => {
-                <Coordinator<LeafModel> as AbstractSimulator>::lambda(leaf, output, t)
-            }
-            HIEnum::Branch(branch) => {
-                <Coordinator<HIModel<W>> as AbstractSimulator>::lambda(branch, output, t)
-            }
-        }
-    }
-
-    fn delta(&mut self, input: &mut Self::Input, output: &mut Self::Output, t: f64) -> f64 {
-        match self {
-            HIEnum::Leaf(leaf) => {
-                <Coordinator<LeafModel> as AbstractSimulator>::delta(leaf, input, output, t)
-            }
-            HIEnum::Branch(branch) => {
-                <Coordinator<HIModel<W>> as AbstractSimulator>::delta(branch, input, output, t)
-            }
         }
     }
 }
@@ -219,7 +166,8 @@ mod test {
 
     #[test]
     fn simulation_matches_expected_counts() {
-        use xdevs::simulation::Simulable;
+        use xdevs::simulation::{AbstractSimulator, Simulable};
+
         const WIDTH: usize = 10;
         const DEPTH: usize = 10;
         const W: usize = WIDTH - 1;

--- a/src/devstone/ho.rs
+++ b/src/devstone/ho.rs
@@ -1,6 +1,6 @@
 use crate::Component;
 
-use super::common::{AtomicModel, JobGenerator};
+use super::common::{AtomicModel, Devstone, JobGenerator};
 
 /// Output struct for HO models (ref version)
 #[derive(Debug, Default, crate::Bag)]
@@ -40,59 +40,21 @@ impl<const W: usize> LeafModel<W> {
     pub fn new() -> Self {
         Self::build(AtomicModel::default())
     }
+}
 
-    pub fn get_n_internals(&self) -> usize {
-        self.components.atomic.get_n_internals()
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        self.components.atomic.get_n_externals()
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        self.components.atomic.get_n_events()
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        self.components.atomic.get_n_atomics()
-    }
+impl<const W: usize> Devstone for LeafModel<W> {
+    crate::impl_devstone_leaf!();
 }
 
 /// HO model enum (ref version)
-#[crate::modelenum]
+#[crate::model_enum]
 pub enum HOEnum<'a, const W: usize> {
     Leaf(LeafModel<W>),
     Branch(HOModel<'a, W>),
 }
 
-impl<'a, const W: usize> HOEnum<'a, W> {
-    pub fn get_n_internals(&self) -> usize {
-        match self {
-            HOEnum::Leaf(leaf) => leaf.get_n_internals(),
-            HOEnum::Branch(branch) => branch.get_n_internals(),
-        }
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        match self {
-            HOEnum::Leaf(leaf) => leaf.get_n_externals(),
-            HOEnum::Branch(branch) => branch.get_n_externals(),
-        }
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        match self {
-            HOEnum::Leaf(leaf) => leaf.get_n_events(),
-            HOEnum::Branch(branch) => branch.get_n_events(),
-        }
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        match self {
-            HOEnum::Leaf(leaf) => leaf.get_n_atomics(),
-            HOEnum::Branch(branch) => branch.get_n_atomics(),
-        }
-    }
+impl<'a, const W: usize> Devstone for HOEnum<'a, W> {
+    crate::impl_devstone_enum!();
 }
 
 /// HO coupled model (ref version)
@@ -106,38 +68,10 @@ impl<'a, const W: usize> HOModel<'a, W> {
     pub fn new(inner: &'a mut HOEnum<'a, W>) -> Self {
         Self::build(core::array::from_fn(|_| AtomicModel::default()), inner)
     }
+}
 
-    pub fn get_n_internals(&self) -> usize {
-        let mut sum_int = self.components.inner.get_n_internals();
-        for atomic in self.components.atomics.iter() {
-            sum_int += atomic.get_n_internals();
-        }
-        sum_int
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        let mut sum_ext = self.components.inner.get_n_externals();
-        for atomic in self.components.atomics.iter() {
-            sum_ext += atomic.get_n_externals();
-        }
-        sum_ext
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        let mut sum_ev = self.components.inner.get_n_events();
-        for atomic in self.components.atomics.iter() {
-            sum_ev += atomic.get_n_events();
-        }
-        sum_ev
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        let mut sum_atomic = self.components.inner.get_n_atomics();
-        for _atomic in self.components.atomics.iter() {
-            sum_atomic += 1;
-        }
-        sum_atomic
-    }
+impl<'a, const W: usize> Devstone for HOModel<'a, W> {
+    crate::impl_devstone_coupled!();
 }
 
 impl<'a, const W: usize> crate::Component for HOModel<'a, W> {
@@ -184,22 +118,8 @@ impl<'a, const W: usize> Component for TopModel<'a, W> {
     type Output = crate::Port<usize, 1>;
 }
 
-impl<'a, const W: usize> TopModel<'a, W> {
-    pub fn get_n_internals(&self) -> usize {
-        self.components.ho_model.get_n_internals()
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        self.components.ho_model.get_n_externals()
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        self.components.ho_model.get_n_events()
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        self.components.ho_model.get_n_atomics()
-    }
+impl<'a, const W: usize> Devstone for TopModel<'a, W> {
+    crate::impl_devstone_top!(ho_model);
 }
 
 impl<'a, const W: usize> crate::Coupled for TopModel<'a, W> {

--- a/src/devstone/ho.rs
+++ b/src/devstone/ho.rs
@@ -1,4 +1,4 @@
-use crate::{simulation::coordinator::Coordinator, AbstractSimulator, Component};
+use crate::Component;
 
 use super::common::{AtomicModel, JobGenerator};
 
@@ -59,9 +59,10 @@ impl<const W: usize> LeafModel<W> {
 }
 
 /// HO model enum (ref version)
+#[crate::modelenum]
 pub enum HOEnum<'a, const W: usize> {
-    Leaf(Coordinator<LeafModel<W>>),
-    Branch(Coordinator<HOModel<'a, W>>),
+    Leaf(LeafModel<W>),
+    Branch(HOModel<'a, W>),
 }
 
 impl<'a, const W: usize> HOEnum<'a, W> {
@@ -90,61 +91,6 @@ impl<'a, const W: usize> HOEnum<'a, W> {
         match self {
             HOEnum::Leaf(leaf) => leaf.get_n_atomics(),
             HOEnum::Branch(branch) => branch.get_n_atomics(),
-        }
-    }
-}
-
-/// Manual implementation of `Component` for HO enum (ref version)
-impl<'a, const W: usize> Component for HOEnum<'a, W> {
-    type Kind = crate::component::ComponentsKind;
-    type Input = crate::Port<usize, 1>;
-    type Output = HOModelOutput<W>;
-}
-
-/// Manual implementation of `AbstractSimulator` for HO enum (ref version)
-unsafe impl<'a, const W: usize> AbstractSimulator for HOEnum<'a, W> {
-    type Input = crate::Port<usize, 1>;
-    type Output = HOModelOutput<W>;
-
-    fn start(&mut self, t_start: f64) -> f64 {
-        match self {
-            HOEnum::Leaf(leaf) => {
-                <Coordinator<LeafModel<W>> as AbstractSimulator>::start(leaf, t_start)
-            }
-            HOEnum::Branch(branch) => {
-                <Coordinator<HOModel<'a, W>> as AbstractSimulator>::start(branch, t_start)
-            }
-        }
-    }
-
-    fn stop(&mut self) {
-        match self {
-            HOEnum::Leaf(leaf) => <Coordinator<LeafModel<W>> as AbstractSimulator>::stop(leaf),
-            HOEnum::Branch(branch) => {
-                <Coordinator<HOModel<'a, W>> as AbstractSimulator>::stop(branch)
-            }
-        }
-    }
-
-    fn lambda(&mut self, output: &mut Self::Output, t: f64) {
-        match self {
-            HOEnum::Leaf(leaf) => {
-                <Coordinator<LeafModel<W>> as AbstractSimulator>::lambda(leaf, output, t)
-            }
-            HOEnum::Branch(branch) => {
-                <Coordinator<HOModel<'a, W>> as AbstractSimulator>::lambda(branch, output, t)
-            }
-        }
-    }
-
-    fn delta(&mut self, input: &mut Self::Input, output: &mut Self::Output, t: f64) -> f64 {
-        match self {
-            HOEnum::Leaf(leaf) => {
-                <Coordinator<LeafModel<W>> as AbstractSimulator>::delta(leaf, input, output, t)
-            }
-            HOEnum::Branch(branch) => {
-                <Coordinator<HOModel<'a, W>> as AbstractSimulator>::delta(branch, input, output, t)
-            }
         }
     }
 }
@@ -268,6 +214,7 @@ impl<'a, const W: usize> crate::Coupled for TopModel<'a, W> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::simulation::AbstractSimulator;
 
     fn expected_n_atomic(width: usize, depth: usize) -> usize {
         (width - 1) * (depth - 1) + 1

--- a/src/devstone/ho_box.rs
+++ b/src/devstone/ho_box.rs
@@ -1,4 +1,4 @@
-use super::common::{AtomicModel, JobGenerator};
+use super::common::{AtomicModel, Devstone, JobGenerator};
 use alloc::boxed::Box;
 use xdevs::Component;
 
@@ -40,59 +40,21 @@ impl<const W: usize> LeafModel<W> {
     pub fn new() -> Self {
         Self::build(AtomicModel::default())
     }
+}
 
-    pub fn get_n_internals(&self) -> usize {
-        self.components.atomic.get_n_internals()
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        self.components.atomic.get_n_externals()
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        self.components.atomic.get_n_events()
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        self.components.atomic.get_n_atomics()
-    }
+impl<const W: usize> Devstone for LeafModel<W> {
+    crate::impl_devstone_leaf!();
 }
 
 /// HO model enum
-#[xdevs::modelenum]
+#[xdevs::model_enum]
 pub enum HOEnum<const W: usize> {
     Leaf(LeafModel<W>),
     Branch(HOModel<W>),
 }
 
-impl<const W: usize> HOEnum<W> {
-    pub fn get_n_internals(&self) -> usize {
-        match self {
-            HOEnum::Leaf(leaf) => leaf.get_n_internals(),
-            HOEnum::Branch(branch) => branch.get_n_internals(),
-        }
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        match self {
-            HOEnum::Leaf(leaf) => leaf.get_n_externals(),
-            HOEnum::Branch(branch) => branch.get_n_externals(),
-        }
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        match self {
-            HOEnum::Leaf(leaf) => leaf.get_n_events(),
-            HOEnum::Branch(branch) => branch.get_n_events(),
-        }
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        match self {
-            HOEnum::Leaf(leaf) => leaf.get_n_atomics(),
-            HOEnum::Branch(branch) => branch.get_n_atomics(),
-        }
-    }
+impl<const W: usize> Devstone for HOEnum<W> {
+    crate::impl_devstone_enum!();
 }
 
 /// HO coupled model
@@ -105,38 +67,10 @@ impl<const W: usize> HOModel<W> {
     pub fn new(inner: Box<HOEnum<W>>) -> Self {
         Self::build(core::array::from_fn(|_| AtomicModel::default()), inner)
     }
+}
 
-    pub fn get_n_internals(&self) -> usize {
-        let mut sum_int = self.components.inner.get_n_internals();
-        for atomic in self.components.atomics.iter() {
-            sum_int += atomic.get_n_internals();
-        }
-        sum_int
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        let mut sum_ext = self.components.inner.get_n_externals();
-        for atomic in self.components.atomics.iter() {
-            sum_ext += atomic.get_n_externals();
-        }
-        sum_ext
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        let mut sum_ev = self.components.inner.get_n_events();
-        for atomic in self.components.atomics.iter() {
-            sum_ev += atomic.get_n_events();
-        }
-        sum_ev
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        let mut sum_atomic = self.components.inner.get_n_atomics();
-        for _atomic in self.components.atomics.iter() {
-            sum_atomic += 1;
-        }
-        sum_atomic
-    }
+impl<const W: usize> Devstone for HOModel<W> {
+    crate::impl_devstone_coupled!();
 }
 impl<const W: usize> xdevs::Component for HOModel<W> {
     type Kind = xdevs::CoupledKind;
@@ -182,22 +116,8 @@ impl<const W: usize> Component for TopModel<W> {
     type Output = xdevs::Port<usize, 1>;
 }
 
-impl<const W: usize> TopModel<W> {
-    pub fn get_n_internals(&self) -> usize {
-        self.components.ho_model.get_n_internals()
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        self.components.ho_model.get_n_externals()
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        self.components.ho_model.get_n_events()
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        self.components.ho_model.get_n_atomics()
-    }
+impl<const W: usize> Devstone for TopModel<W> {
+    crate::impl_devstone_top!(ho_model);
 }
 
 impl<const W: usize> xdevs::Coupled for TopModel<W> {

--- a/src/devstone/ho_box.rs
+++ b/src/devstone/ho_box.rs
@@ -1,5 +1,3 @@
-use crate::{simulation::coordinator::Coordinator, AbstractSimulator};
-
 use super::common::{AtomicModel, JobGenerator};
 use alloc::boxed::Box;
 use xdevs::Component;
@@ -61,9 +59,10 @@ impl<const W: usize> LeafModel<W> {
 }
 
 /// HO model enum
+#[xdevs::modelenum]
 pub enum HOEnum<const W: usize> {
-    Leaf(Coordinator<LeafModel<W>>),
-    Branch(Coordinator<HOModel<W>>),
+    Leaf(LeafModel<W>),
+    Branch(HOModel<W>),
 }
 
 impl<const W: usize> HOEnum<W> {
@@ -92,58 +91,6 @@ impl<const W: usize> HOEnum<W> {
         match self {
             HOEnum::Leaf(leaf) => leaf.get_n_atomics(),
             HOEnum::Branch(branch) => branch.get_n_atomics(),
-        }
-    }
-}
-
-/// Manual implementation of `Component` for HO enum
-impl<const W: usize> Component for HOEnum<W> {
-    type Kind = xdevs::ComponentsKind;
-    type Input = xdevs::Port<usize, 1>;
-    type Output = HOModelOutput<W>;
-}
-
-/// Manual implementation of `AbstractSimulator` for HO enum
-unsafe impl<const W: usize> AbstractSimulator for HOEnum<W> {
-    type Input = xdevs::Port<usize, 1>;
-    type Output = HOModelOutput<W>;
-    fn start(&mut self, t_start: f64) -> f64 {
-        match self {
-            HOEnum::Leaf(leaf) => {
-                <Coordinator<LeafModel<W>> as AbstractSimulator>::start(leaf, t_start)
-            }
-            HOEnum::Branch(branch) => {
-                <Coordinator<HOModel<W>> as AbstractSimulator>::start(branch, t_start)
-            }
-        }
-    }
-
-    fn stop(&mut self) {
-        match self {
-            HOEnum::Leaf(leaf) => <Coordinator<LeafModel<W>> as AbstractSimulator>::stop(leaf),
-            HOEnum::Branch(branch) => <Coordinator<HOModel<W>> as AbstractSimulator>::stop(branch),
-        }
-    }
-
-    fn lambda(&mut self, output: &mut Self::Output, t: f64) {
-        match self {
-            HOEnum::Leaf(leaf) => {
-                <Coordinator<LeafModel<W>> as AbstractSimulator>::lambda(leaf, output, t)
-            }
-            HOEnum::Branch(branch) => {
-                <Coordinator<HOModel<W>> as AbstractSimulator>::lambda(branch, output, t)
-            }
-        }
-    }
-
-    fn delta(&mut self, input: &mut Self::Input, output: &mut Self::Output, t: f64) -> f64 {
-        match self {
-            HOEnum::Leaf(leaf) => {
-                <Coordinator<LeafModel<W>> as AbstractSimulator>::delta(leaf, input, output, t)
-            }
-            HOEnum::Branch(branch) => {
-                <Coordinator<HOModel<W>> as AbstractSimulator>::delta(branch, input, output, t)
-            }
         }
     }
 }
@@ -276,7 +223,8 @@ mod test {
 
     #[test]
     fn simulation_matches_expected_counts() {
-        use xdevs::simulation::Simulable;
+        use xdevs::simulation::{AbstractSimulator, Simulable};
+
         const WIDTH: usize = 10;
         const DEPTH: usize = 10;
         const W: usize = WIDTH - 1;

--- a/src/devstone/li.rs
+++ b/src/devstone/li.rs
@@ -1,42 +1,15 @@
+use super::common::{AtomicModel, Devstone, JobGenerator, LeafModel};
 use crate::Component;
 
-use super::common::*;
-
 /// LI model enum (ref version)
-#[crate::modelenum]
+#[crate::model_enum]
 pub enum LIEnum<'a, const W: usize> {
     Leaf(LeafModel),
     Branch(LIModel<'a, W>),
 }
 
-impl<'a, const W: usize> LIEnum<'a, W> {
-    pub fn get_n_internals(&self) -> usize {
-        match self {
-            LIEnum::Leaf(leaf) => leaf.get_n_internals(),
-            LIEnum::Branch(branch) => branch.get_n_internals(),
-        }
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        match self {
-            LIEnum::Leaf(leaf) => leaf.get_n_externals(),
-            LIEnum::Branch(branch) => branch.get_n_externals(),
-        }
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        match self {
-            LIEnum::Leaf(leaf) => leaf.get_n_events(),
-            LIEnum::Branch(branch) => branch.get_n_events(),
-        }
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        match self {
-            LIEnum::Leaf(leaf) => leaf.get_n_atomics(),
-            LIEnum::Branch(branch) => branch.get_n_atomics(),
-        }
-    }
+impl<'a, const W: usize> Devstone for LIEnum<'a, W> {
+    crate::impl_devstone_enum!();
 }
 
 /// LI coupled model (ref version)
@@ -70,38 +43,10 @@ impl<'a, const W: usize> LIModel<'a, W> {
     pub fn new(inner: &'a mut LIEnum<'a, W>) -> Self {
         Self::build(core::array::from_fn(|_| AtomicModel::default()), inner)
     }
+}
 
-    pub fn get_n_internals(&self) -> usize {
-        let mut sum_int = self.components.inner.get_n_internals();
-        for atomic in self.components.atomics.iter() {
-            sum_int += atomic.get_n_internals();
-        }
-        sum_int
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        let mut sum_ext = self.components.inner.get_n_externals();
-        for atomic in self.components.atomics.iter() {
-            sum_ext += atomic.get_n_externals();
-        }
-        sum_ext
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        let mut sum_ev = self.components.inner.get_n_events();
-        for atomic in self.components.atomics.iter() {
-            sum_ev += atomic.get_n_events();
-        }
-        sum_ev
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        let mut sum_atomic = self.components.inner.get_n_atomics();
-        for _atomic in self.components.atomics.iter() {
-            sum_atomic += 1;
-        }
-        sum_atomic
-    }
+impl<'a, const W: usize> Devstone for LIModel<'a, W> {
+    crate::impl_devstone_coupled!();
 }
 
 /// End model with Generator and LI model coupled together (ref version)
@@ -117,22 +62,8 @@ impl<'a, const W: usize> Component for TopModel<'a, W> {
     type Output = ();
 }
 
-impl<'a, const W: usize> TopModel<'a, W> {
-    pub fn get_n_internals(&self) -> usize {
-        self.components.li_model.get_n_internals()
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        self.components.li_model.get_n_externals()
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        self.components.li_model.get_n_events()
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        self.components.li_model.get_n_atomics()
-    }
+impl<'a, const W: usize> Devstone for TopModel<'a, W> {
+    crate::impl_devstone_top!(li_model);
 }
 
 impl<'a, const W: usize> crate::Coupled for TopModel<'a, W> {

--- a/src/devstone/li.rs
+++ b/src/devstone/li.rs
@@ -1,11 +1,12 @@
-use crate::{simulation::coordinator::Coordinator, AbstractSimulator, Component};
+use crate::Component;
 
 use super::common::*;
 
 /// LI model enum (ref version)
+#[crate::modelenum]
 pub enum LIEnum<'a, const W: usize> {
-    Leaf(Coordinator<LeafModel>),
-    Branch(Coordinator<LIModel<'a, W>>),
+    Leaf(LeafModel),
+    Branch(LIModel<'a, W>),
 }
 
 impl<'a, const W: usize> LIEnum<'a, W> {
@@ -34,61 +35,6 @@ impl<'a, const W: usize> LIEnum<'a, W> {
         match self {
             LIEnum::Leaf(leaf) => leaf.get_n_atomics(),
             LIEnum::Branch(branch) => branch.get_n_atomics(),
-        }
-    }
-}
-
-/// Manual implementation of `Component` for LI enum (ref version)
-impl<'a, const W: usize> Component for LIEnum<'a, W> {
-    type Kind = crate::component::ComponentsKind;
-    type Input = crate::Port<usize, 1>;
-    type Output = crate::Port<usize, 1>;
-}
-
-/// Manual implementation of `AbstractSimulator` for LI enum (ref version)
-unsafe impl<'a, const W: usize> AbstractSimulator for LIEnum<'a, W> {
-    type Input = crate::Port<usize, 1>;
-    type Output = crate::Port<usize, 1>;
-
-    fn start(&mut self, t_start: f64) -> f64 {
-        match self {
-            LIEnum::Leaf(leaf) => {
-                <Coordinator<LeafModel> as AbstractSimulator>::start(leaf, t_start)
-            }
-            LIEnum::Branch(branch) => {
-                <Coordinator<LIModel<'a, W>> as AbstractSimulator>::start(branch, t_start)
-            }
-        }
-    }
-
-    fn stop(&mut self) {
-        match self {
-            LIEnum::Leaf(leaf) => <Coordinator<LeafModel> as AbstractSimulator>::stop(leaf),
-            LIEnum::Branch(branch) => {
-                <Coordinator<LIModel<'a, W>> as AbstractSimulator>::stop(branch)
-            }
-        }
-    }
-
-    fn lambda(&mut self, output: &mut Self::Output, t: f64) {
-        match self {
-            LIEnum::Leaf(leaf) => {
-                <Coordinator<LeafModel> as AbstractSimulator>::lambda(leaf, output, t)
-            }
-            LIEnum::Branch(branch) => {
-                <Coordinator<LIModel<'a, W>> as AbstractSimulator>::lambda(branch, output, t)
-            }
-        }
-    }
-
-    fn delta(&mut self, input: &mut Self::Input, output: &mut Self::Output, t: f64) -> f64 {
-        match self {
-            LIEnum::Leaf(leaf) => {
-                <Coordinator<LeafModel> as AbstractSimulator>::delta(leaf, input, output, t)
-            }
-            LIEnum::Branch(branch) => {
-                <Coordinator<LIModel<'a, W>> as AbstractSimulator>::delta(branch, input, output, t)
-            }
         }
     }
 }
@@ -201,6 +147,7 @@ impl<'a, const W: usize> crate::Coupled for TopModel<'a, W> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::simulation::AbstractSimulator;
 
     fn expected_n_atomic(width: usize, depth: usize) -> usize {
         (width - 1) * (depth - 1) + 1

--- a/src/devstone/li_box.rs
+++ b/src/devstone/li_box.rs
@@ -1,41 +1,15 @@
-use super::common::*;
+use super::common::{AtomicModel, Devstone, JobGenerator, LeafModel};
 use alloc::boxed::Box;
 use xdevs::Component;
 
-#[xdevs::modelenum]
+#[xdevs::model_enum]
 pub enum LIEnum<const W: usize> {
     Leaf(LeafModel),
     Branch(LIModel<W>),
 }
 
-impl<const W: usize> LIEnum<W> {
-    pub fn get_n_internals(&self) -> usize {
-        match self {
-            LIEnum::Leaf(leaf) => leaf.get_n_internals(),
-            LIEnum::Branch(branch) => branch.get_n_internals(),
-        }
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        match self {
-            LIEnum::Leaf(leaf) => leaf.get_n_externals(),
-            LIEnum::Branch(branch) => branch.get_n_externals(),
-        }
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        match self {
-            LIEnum::Leaf(leaf) => leaf.get_n_events(),
-            LIEnum::Branch(branch) => branch.get_n_events(),
-        }
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        match self {
-            LIEnum::Leaf(leaf) => leaf.get_n_atomics(),
-            LIEnum::Branch(branch) => branch.get_n_atomics(),
-        }
-    }
+impl<const W: usize> Devstone for LIEnum<W> {
+    crate::impl_devstone_enum!();
 }
 
 /// LI coupled model
@@ -69,38 +43,10 @@ impl<const W: usize> LIModel<W> {
     pub fn new(inner: Box<LIEnum<W>>) -> Self {
         Self::build(core::array::from_fn(|_| AtomicModel::default()), inner)
     }
+}
 
-    pub fn get_n_internals(&self) -> usize {
-        let mut sum_int = self.components.inner.get_n_internals();
-        for atomic in self.components.atomics.iter() {
-            sum_int += atomic.get_n_internals();
-        }
-        sum_int
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        let mut sum_ext = self.components.inner.get_n_externals();
-        for atomic in self.components.atomics.iter() {
-            sum_ext += atomic.get_n_externals();
-        }
-        sum_ext
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        let mut sum_ev = self.components.inner.get_n_events();
-        for atomic in self.components.atomics.iter() {
-            sum_ev += atomic.get_n_events();
-        }
-        sum_ev
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        let mut sum_atomic = self.components.inner.get_n_atomics();
-        for _atomic in self.components.atomics.iter() {
-            sum_atomic += 1;
-        }
-        sum_atomic
-    }
+impl<const W: usize> Devstone for LIModel<W> {
+    crate::impl_devstone_coupled!();
 }
 
 /// End model with Generator and LI model coupled together
@@ -116,22 +62,8 @@ impl<const W: usize> Component for TopModel<W> {
     type Output = ();
 }
 
-impl<const W: usize> TopModel<W> {
-    pub fn get_n_internals(&self) -> usize {
-        self.components.li_model.get_n_internals()
-    }
-
-    pub fn get_n_externals(&self) -> usize {
-        self.components.li_model.get_n_externals()
-    }
-
-    pub fn get_n_events(&self) -> usize {
-        self.components.li_model.get_n_events()
-    }
-
-    pub fn get_n_atomics(&self) -> usize {
-        self.components.li_model.get_n_atomics()
-    }
+impl<const W: usize> Devstone for TopModel<W> {
+    crate::impl_devstone_top!(li_model);
 }
 
 impl<const W: usize> xdevs::Coupled for TopModel<W> {

--- a/src/devstone/li_box.rs
+++ b/src/devstone/li_box.rs
@@ -1,12 +1,11 @@
-use crate::{simulation::coordinator::Coordinator, AbstractSimulator};
-
 use super::common::*;
 use alloc::boxed::Box;
 use xdevs::Component;
 
+#[xdevs::modelenum]
 pub enum LIEnum<const W: usize> {
-    Leaf(Coordinator<LeafModel>),
-    Branch(Coordinator<LIModel<W>>),
+    Leaf(LeafModel),
+    Branch(LIModel<W>),
 }
 
 impl<const W: usize> LIEnum<W> {
@@ -35,59 +34,6 @@ impl<const W: usize> LIEnum<W> {
         match self {
             LIEnum::Leaf(leaf) => leaf.get_n_atomics(),
             LIEnum::Branch(branch) => branch.get_n_atomics(),
-        }
-    }
-}
-
-/// Manual implementation of `Component` for LI enum
-impl<const W: usize> Component for LIEnum<W> {
-    type Kind = xdevs::ComponentsKind;
-    type Input = xdevs::Port<usize, 1>;
-    type Output = xdevs::Port<usize, 1>;
-}
-
-/// Manual implementation of `AbstractSimulator` for LI enum
-unsafe impl<const W: usize> AbstractSimulator for LIEnum<W> {
-    type Input = xdevs::Port<usize, 1>;
-    type Output = xdevs::Port<usize, 1>;
-
-    fn start(&mut self, t_start: f64) -> f64 {
-        match self {
-            LIEnum::Leaf(leaf) => {
-                <Coordinator<LeafModel> as AbstractSimulator>::start(leaf, t_start)
-            }
-            LIEnum::Branch(branch) => {
-                <Coordinator<LIModel<W>> as AbstractSimulator>::start(branch, t_start)
-            }
-        }
-    }
-
-    fn stop(&mut self) {
-        match self {
-            LIEnum::Leaf(leaf) => <Coordinator<LeafModel> as AbstractSimulator>::stop(leaf),
-            LIEnum::Branch(branch) => <Coordinator<LIModel<W>> as AbstractSimulator>::stop(branch),
-        }
-    }
-
-    fn lambda(&mut self, output: &mut Self::Output, t: f64) {
-        match self {
-            LIEnum::Leaf(leaf) => {
-                <Coordinator<LeafModel> as AbstractSimulator>::lambda(leaf, output, t)
-            }
-            LIEnum::Branch(branch) => {
-                <Coordinator<LIModel<W>> as AbstractSimulator>::lambda(branch, output, t)
-            }
-        }
-    }
-
-    fn delta(&mut self, input: &mut Self::Input, output: &mut Self::Output, t: f64) -> f64 {
-        match self {
-            LIEnum::Leaf(leaf) => {
-                <Coordinator<LeafModel> as AbstractSimulator>::delta(leaf, input, output, t)
-            }
-            LIEnum::Branch(branch) => {
-                <Coordinator<LIModel<W>> as AbstractSimulator>::delta(branch, input, output, t)
-            }
         }
     }
 }
@@ -210,7 +156,8 @@ mod test {
 
     #[test]
     fn simulation_matches_expected_counts() {
-        use xdevs::simulation::Simulable;
+        use xdevs::simulation::{AbstractSimulator, Simulable};
+
         const WIDTH: usize = 10;
         const DEPTH: usize = 10;
         const W: usize = WIDTH - 1;


### PR DESCRIPTION
Add a macro called #[xdevs::modelenum] to create enums of models with the same Input and Output types.

This macro has then been applied to DEVStone and a new example showcasing it.

Finally, a Devstone trait, whose implementation has been automated through macros has been created to guarantee that all DEVStone models have the correct functions for testing and to further reduce their code size.

The name modelenum is no set in stone. Other naming suggestions are welcome.