### PR TITLE
to_component macro

### DIFF
--- a/examples/gpt_array.rs
+++ b/examples/gpt_array.rs
@@ -8,7 +8,7 @@ use xdevs::{
 };
 
 /// Coupled model with an array of processor-transducer pairs.
-#[xdevs::coupled]
+#[xdevs::to_component]
 struct GPTArray<const N: usize> {
     generator: Generator,
     processors: [Processor; N],

--- a/examples/gpt_enum.rs
+++ b/examples/gpt_enum.rs
@@ -1,4 +1,4 @@
-/// Illustrates #[xdevs::model_enum]: a GPT model where the processor is
+/// Illustrates #[xdevs::to_component] on an enum: a GPT model where the processor is
 /// chosen at build time between a fast and a slow variant, without any
 /// conditional logic in the coupled model.
 use xdevs::{
@@ -107,14 +107,14 @@ mod processor {
         }
     }
 
-    #[xdevs::model_enum]
+    #[xdevs::to_component]
     pub enum Processor {
         Fast(FastProcessor),
         Slow(SlowProcessor),
     }
 }
 
-#[xdevs::coupled]
+#[xdevs::to_component]
 pub struct GPT {
     generator: Generator,
     processor: processor::Processor,

--- a/examples/gpt_optional.rs
+++ b/examples/gpt_optional.rs
@@ -10,7 +10,7 @@ use xdevs::{
 ///
 /// The coupling code routes unconditionally (same type whether present or not).
 /// When the processor is `None`, it silently absorbs any routed events in its `delta`.
-#[xdevs::coupled]
+#[xdevs::to_component]
 pub struct GPTOptional {
     generator: Generator,
     processor: Option<Processor>,

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -7,26 +7,36 @@ mod devstone;
 mod model_enum;
 mod rt_engine;
 
-/// Main macro to generate coupled DEVS models
+/// Macro to generate DEVS components.
+///
+/// On a struct, behaves like the old `#[coupled]` macro — generates a coupled model.
+/// On an enum, behaves like the old `#[model_enum]` macro — generates an enum-based component.
 #[proc_macro_attribute]
-pub fn coupled(_args: TokenStream, item: TokenStream) -> TokenStream {
-    let item = parse_macro_input!(item as syn::ItemStruct);
+pub fn to_component(_args: TokenStream, item: TokenStream) -> TokenStream {
+    let item2 = item.clone();
 
-    match coupled::expand(item) {
-        Ok(component) => component.into(),
-        Err(err) => err.to_compile_error().into(),
+    // Try parsing as a struct first (coupled model)
+    if let Ok(item_struct) = syn::parse::<syn::ItemStruct>(item2) {
+        return match coupled::expand(item_struct) {
+            Ok(component) => component.into(),
+            Err(err) => err.to_compile_error().into(),
+        };
     }
-}
 
-/// Macro to generate enum-based DEVS components
-#[proc_macro_attribute]
-pub fn model_enum(_args: TokenStream, item: TokenStream) -> TokenStream {
-    let item = parse_macro_input!(item as syn::ItemEnum);
-
-    match model_enum::expand(item) {
-        Ok(component) => component.into(),
-        Err(err) => err.to_compile_error().into(),
+    // Then try parsing as an enum (enum-based model)
+    let item2 = item.clone();
+    if let Ok(item_enum) = syn::parse::<syn::ItemEnum>(item2) {
+        return match model_enum::expand(item_enum) {
+            Ok(component) => component.into(),
+            Err(err) => err.to_compile_error().into(),
+        };
     }
+
+    let err = Error::new(
+        proc_macro2::Span::call_site(),
+        "#[to_component] requires a struct (for coupled models) or an enum (for enum-based models)",
+    );
+    err.to_compile_error().into()
 }
 
 /// Macro to generate RT engine components

--- a/src/component/coupled.rs
+++ b/src/component/coupled.rs
@@ -101,8 +101,6 @@ impl<T: Coupled> Coupled for alloc::boxed::Box<T> {
 
 #[cfg(test)]
 mod tests {
-    use xdevs_no_std_macros::coupled;
-
     use super::{ComponentsInput, ComponentsOutput, Coupled, PartialCoupled};
     use crate::{
         component::CoupledKind,
@@ -111,7 +109,7 @@ mod tests {
         Component,
     };
 
-    #[coupled]
+    #[crate::to_component]
     struct ForwardChain {
         components: [Processor; 2],
     }

--- a/src/devstone/common.rs
+++ b/src/devstone/common.rs
@@ -115,7 +115,7 @@ impl Devstone for AtomicModel {
 }
 
 /// Leaf coupled model with only one atomic in LI models and HI leaf model
-#[xdevs::coupled]
+#[xdevs::to_component]
 pub struct LeafModel {
     atomic: AtomicModel,
 }

--- a/src/devstone/hi.rs
+++ b/src/devstone/hi.rs
@@ -2,7 +2,7 @@ use super::common::{AtomicModel, Devstone, JobGenerator, LeafModel};
 use crate::Component;
 
 /// HI model enum (ref version)
-#[crate::model_enum]
+#[crate::to_component]
 pub enum HIEnum<'a, const W: usize> {
     Leaf(LeafModel),
     Branch(HIModel<'a, W>),
@@ -13,7 +13,7 @@ impl<'a, const W: usize> Devstone for HIEnum<'a, W> {
 }
 
 /// HI coupled model (ref version)
-#[crate::coupled]
+#[crate::to_component]
 pub struct HIModel<'a, const W: usize> {
     atomics: [AtomicModel; W],
     inner: &'a mut HIEnum<'a, W>,
@@ -59,7 +59,7 @@ impl<'a, const W: usize> Devstone for HIModel<'a, W> {
 }
 
 /// End model with Generator and HI model coupled together (ref version)
-#[crate::coupled]
+#[crate::to_component]
 pub struct TopModel<'a, const W: usize> {
     generator: JobGenerator,
     hi_model: &'a mut HIEnum<'a, W>,

--- a/src/devstone/hi_box.rs
+++ b/src/devstone/hi_box.rs
@@ -3,7 +3,7 @@ use crate::Component;
 use alloc::boxed::Box;
 
 /// HI model enum
-#[xdevs::model_enum]
+#[xdevs::to_component]
 pub enum HIEnum<const W: usize> {
     Leaf(LeafModel),
     Branch(HIModel<W>),
@@ -14,7 +14,7 @@ impl<const W: usize> Devstone for HIEnum<W> {
 }
 
 /// HI coupled model
-#[xdevs::coupled]
+#[xdevs::to_component]
 pub struct HIModel<const W: usize> {
     atomics: [AtomicModel; W],
     inner: Box<HIEnum<W>>,
@@ -60,7 +60,7 @@ impl<const W: usize> Devstone for HIModel<W> {
 }
 
 /// End model with Generator and HI model coupled together
-#[xdevs::coupled]
+#[xdevs::to_component]
 pub struct TopModel<const W: usize> {
     generator: JobGenerator,
     hi_model: HIEnum<W>,

--- a/src/devstone/ho.rs
+++ b/src/devstone/ho.rs
@@ -10,7 +10,7 @@ pub struct HOModelOutput<const W: usize> {
 }
 
 /// Leaf coupled model with only one atomic in HO models (ref version)
-#[crate::coupled]
+#[crate::to_component]
 pub struct LeafModel<const W: usize> {
     atomic: AtomicModel,
 }
@@ -47,7 +47,7 @@ impl<const W: usize> Devstone for LeafModel<W> {
 }
 
 /// HO model enum (ref version)
-#[crate::model_enum]
+#[crate::to_component]
 pub enum HOEnum<'a, const W: usize> {
     Leaf(LeafModel<W>),
     Branch(HOModel<'a, W>),
@@ -58,7 +58,7 @@ impl<'a, const W: usize> Devstone for HOEnum<'a, W> {
 }
 
 /// HO coupled model (ref version)
-#[crate::coupled]
+#[crate::to_component]
 pub struct HOModel<'a, const W: usize> {
     atomics: [AtomicModel; W],
     inner: &'a mut HOEnum<'a, W>,
@@ -106,7 +106,7 @@ impl<'a, const W: usize> crate::Coupled for HOModel<'a, W> {
 }
 
 /// End model with Generator and HO model coupled together (ref version)
-#[crate::coupled]
+#[crate::to_component]
 pub struct TopModel<'a, const W: usize> {
     generator: JobGenerator,
     ho_model: &'a mut HOEnum<'a, W>,

--- a/src/devstone/ho_box.rs
+++ b/src/devstone/ho_box.rs
@@ -10,7 +10,7 @@ pub struct HOModelOutput<const W: usize> {
 }
 
 /// Leaf coupled model with only one atomic in HO models
-#[xdevs::coupled]
+#[xdevs::to_component]
 pub struct LeafModel<const W: usize> {
     atomic: AtomicModel,
 }
@@ -47,7 +47,7 @@ impl<const W: usize> Devstone for LeafModel<W> {
 }
 
 /// HO model enum
-#[xdevs::model_enum]
+#[xdevs::to_component]
 pub enum HOEnum<const W: usize> {
     Leaf(LeafModel<W>),
     Branch(HOModel<W>),
@@ -58,7 +58,7 @@ impl<const W: usize> Devstone for HOEnum<W> {
 }
 
 /// HO coupled model
-#[xdevs::coupled]
+#[xdevs::to_component]
 pub struct HOModel<const W: usize> {
     atomics: [AtomicModel; W],
     inner: Box<HOEnum<W>>,
@@ -104,7 +104,7 @@ impl<const W: usize> xdevs::Coupled for HOModel<W> {
 }
 
 /// End model with Generator and HO model coupled together
-#[xdevs::coupled]
+#[xdevs::to_component]
 pub struct TopModel<const W: usize> {
     generator: JobGenerator,
     ho_model: HOEnum<W>,

--- a/src/devstone/li.rs
+++ b/src/devstone/li.rs
@@ -2,7 +2,7 @@ use super::common::{AtomicModel, Devstone, JobGenerator, LeafModel};
 use crate::Component;
 
 /// LI model enum (ref version)
-#[crate::model_enum]
+#[crate::to_component]
 pub enum LIEnum<'a, const W: usize> {
     Leaf(LeafModel),
     Branch(LIModel<'a, W>),
@@ -13,7 +13,7 @@ impl<'a, const W: usize> Devstone for LIEnum<'a, W> {
 }
 
 /// LI coupled model (ref version)
-#[crate::coupled]
+#[crate::to_component]
 pub struct LIModel<'a, const W: usize> {
     atomics: [AtomicModel; W],
     inner: &'a mut LIEnum<'a, W>,
@@ -50,7 +50,7 @@ impl<'a, const W: usize> Devstone for LIModel<'a, W> {
 }
 
 /// End model with Generator and LI model coupled together (ref version)
-#[crate::coupled]
+#[crate::to_component]
 pub struct TopModel<'a, const W: usize> {
     generator: JobGenerator,
     li_model: &'a mut LIEnum<'a, W>,

--- a/src/devstone/li_box.rs
+++ b/src/devstone/li_box.rs
@@ -2,7 +2,7 @@ use super::common::{AtomicModel, Devstone, JobGenerator, LeafModel};
 use alloc::boxed::Box;
 use xdevs::Component;
 
-#[xdevs::model_enum]
+#[xdevs::to_component]
 pub enum LIEnum<const W: usize> {
     Leaf(LeafModel),
     Branch(LIModel<W>),
@@ -13,7 +13,7 @@ impl<const W: usize> Devstone for LIEnum<W> {
 }
 
 /// LI coupled model
-#[xdevs::coupled]
+#[xdevs::to_component]
 pub struct LIModel<const W: usize> {
     atomics: [AtomicModel; W],
     inner: Box<LIEnum<W>>,
@@ -50,7 +50,7 @@ impl<const W: usize> Devstone for LIModel<W> {
 }
 
 /// End model with Generator and LI model coupled together
-#[xdevs::coupled]
+#[xdevs::to_component]
 pub struct TopModel<const W: usize> {
     generator: JobGenerator,
     li_model: LIEnum<W>,

--- a/src/gpt.rs
+++ b/src/gpt.rs
@@ -187,7 +187,7 @@ impl Transducer {
     }
 }
 
-#[xdevs::coupled]
+#[xdevs::to_component]
 pub struct GPT {
     generator: Generator,
     processor: Processor,
@@ -216,7 +216,7 @@ impl xdevs::Coupled for GPT {
     }
 }
 
-#[xdevs::coupled]
+#[xdevs::to_component]
 pub struct EF {
     generator: Generator,
     transducer: Transducer,
@@ -246,7 +246,7 @@ impl xdevs::Coupled for EF {
     }
 }
 
-#[xdevs::coupled]
+#[xdevs::to_component]
 pub struct EFP {
     ef: EF,
     processor: Processor,

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -60,7 +60,7 @@ impl Default for Config {
 ///
 /// # Safety
 ///
-/// This trait must be implemented internally or via the [`coupled`](crate::coupled) macro. Do not implement it manually.
+/// This trait must be implemented internally or via the [`to_component`](crate::to_component) macro. Do not implement it manually.
 pub unsafe trait AbstractSimulator {
     type Input: Bag;
 
@@ -486,7 +486,7 @@ pub(crate) mod test_utils {
         }
     }
 
-    #[crate::coupled]
+    #[crate::to_component]
     pub(crate) struct TestCoupled {
         pub a0: TestAtomic,
         pub a1: TestAtomic,
@@ -510,7 +510,7 @@ pub(crate) mod test_utils {
         }
     }
 
-    #[crate::coupled]
+    #[crate::to_component]
     pub(crate) struct TestCoupledWithOption {
         pub a0: TestAtomic,
         pub opt: Option<TestAtomic>,


### PR DESCRIPTION
Create a new to_component macro that has the functionality of the old #[xdevs::coupled] macro when applied to structs and #[xdevs::model_enum] When applied to enums.