### PR TITLE
Add a prelude

### DIFF
--- a/benches/hi.rs
+++ b/benches/hi.rs
@@ -2,7 +2,9 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use xdevs::{
     devstone::common::{Devstone, JobGenerator},
     devstone::hi,
-    generate_hi, AbstractSimulator, Config, Simulable,
+    generate_hi,
+    prelude::*,
+    Config,
 };
 #[cfg(feature = "alloc")]
 use xdevs::{devstone::hi_box, generate_hi_box};

--- a/benches/ho.rs
+++ b/benches/ho.rs
@@ -2,7 +2,9 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use xdevs::{
     devstone::common::{Devstone, JobGenerator},
     devstone::ho,
-    generate_ho, AbstractSimulator, Config, Simulable,
+    generate_ho,
+    prelude::*,
+    Config,
 };
 #[cfg(feature = "alloc")]
 use xdevs::{devstone::ho_box, generate_ho_box};

--- a/benches/li.rs
+++ b/benches/li.rs
@@ -2,7 +2,9 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use xdevs::{
     devstone::common::{Devstone, JobGenerator},
     devstone::li,
-    generate_li, AbstractSimulator, Config, Simulable,
+    generate_li,
+    prelude::*,
+    Config,
 };
 #[cfg(feature = "alloc")]
 use xdevs::{devstone::li_box, generate_li_box};

--- a/examples/gpt.rs
+++ b/examples/gpt.rs
@@ -1,7 +1,8 @@
 /// A simple DEVS GPT model using the library gpt module.
 use xdevs::{
     gpt::{Generator, Processor, Transducer, EF, EFP},
-    AbstractSimulator, Config, Simulable,
+    prelude::*,
+    Config,
 };
 
 fn main() {

--- a/examples/gpt_array.rs
+++ b/examples/gpt_array.rs
@@ -4,7 +4,8 @@
 /// The last Transducer sends the stop signal back to the Generator.
 use xdevs::{
     gpt::{Generator, Processor, Transducer},
-    AbstractSimulator, ComponentsInput, ComponentsOutput, Config, CoupledKind, Simulable,
+    prelude::*,
+    ComponentsInput, ComponentsOutput, Config, CoupledKind,
 };
 
 /// Coupled model with an array of processor-transducer pairs.

--- a/examples/gpt_async.rs
+++ b/examples/gpt_async.rs
@@ -1,8 +1,9 @@
 /// A simple DEVS GPT model using the library gpt module with async simulation.
 use xdevs::{
     gpt::{Generator, Processor, Transducer, GPT},
+    prelude::*,
     simulation::std::SleepAsync,
-    AbstractSimulator, Config, Simulable,
+    Config,
 };
 
 #[tokio::main]

--- a/examples/gpt_enum.rs
+++ b/examples/gpt_enum.rs
@@ -3,7 +3,8 @@
 /// conditional logic in the coupled model.
 use xdevs::{
     gpt::{Generator, Transducer},
-    AbstractSimulator, CoupledKind, Simulable,
+    prelude::*,
+    CoupledKind,
 };
 
 mod processor {

--- a/examples/gpt_optional.rs
+++ b/examples/gpt_optional.rs
@@ -1,7 +1,8 @@
 /// GPT-like example with an optional processor, using the library gpt module.
 use xdevs::{
     gpt::{Generator, Processor, Transducer},
-    AbstractSimulator, ComponentsInput, ComponentsOutput, CoupledKind, Simulable,
+    prelude::*,
+    ComponentsInput, ComponentsOutput, CoupledKind,
 };
 
 /// Coupled model with an optional processor, demonstrates

--- a/examples/rt_engine.rs
+++ b/examples/rt_engine.rs
@@ -1,16 +1,16 @@
 /// This example demonstrates how the rt_engine can be used to simplify the DEVS simulation
 /// interaction with other tasks. An array is used for the input to showcase how the input enum
 /// would look like for an input array.
-use xdevs::{AtomicKind, Config};
+use xdevs::{AtomicKind, Config, Port};
 
 #[derive(xdevs::Bag, xdevs::BagMux)]
 pub struct TransparentInput {
-    pub in_job: [xdevs::Port<usize, 1>; 3],
+    pub in_job: [Port<usize, 1>; 3],
 }
 
 #[derive(xdevs::Bag, xdevs::BagMux)]
 pub struct TransparentOutput {
-    pub out_job: xdevs::Port<usize, 1>,
+    pub out_job: Port<usize, 1>,
 }
 
 pub struct Transparent {

--- a/src/bin/devstone_generator.rs
+++ b/src/bin/devstone_generator.rs
@@ -166,7 +166,7 @@ fn render_example(
     use std::time::Instant;
 {alloc_line}
     fn main() {{
-        use xdevs::{{AbstractSimulator, Simulable}};
+        use xdevs::prelude::*;
 
         const WIDTH: usize = {width};
         const W: usize = WIDTH - 1;

--- a/src/component/atomic.rs
+++ b/src/component/atomic.rs
@@ -1,4 +1,4 @@
-use crate::component::{AtomicKind, Component};
+use crate::{AtomicKind, Component};
 
 /// Interface for DEVS atomic models. All DEVS atomic models must implement this trait.
 pub trait Atomic: Component<Kind = AtomicKind> {

--- a/src/component/coupled.rs
+++ b/src/component/coupled.rs
@@ -1,7 +1,4 @@
-use crate::{
-    component::{Component, CoupledKind},
-    simulation::AbstractSimulator,
-};
+use crate::{simulation::AbstractSimulator, Component, CoupledKind};
 
 /// Partial interface for DEVS coupled models. All DEVS coupled models must implement this trait.
 pub trait PartialCoupled: Component<Kind = CoupledKind> {

--- a/src/devstone/common.rs
+++ b/src/devstone/common.rs
@@ -10,13 +10,13 @@ pub struct JobGenerator {
     count: usize,
 }
 
-impl xdevs::Component for JobGenerator {
-    type Kind = xdevs::AtomicKind;
+impl crate::Component for JobGenerator {
+    type Kind = crate::AtomicKind;
     type Input = ();
-    type Output = xdevs::Port<usize, 1>;
+    type Output = crate::Port<usize, 1>;
 }
 
-impl xdevs::Atomic for JobGenerator {
+impl crate::Atomic for JobGenerator {
     fn delta_int(&mut self) {
         self.sigma = f64::INFINITY;
     }
@@ -75,13 +75,13 @@ fn burn_cycles(duration: Duration) {
     }
 }
 
-impl xdevs::Component for AtomicModel {
-    type Kind = xdevs::AtomicKind;
-    type Input = xdevs::Port<usize, 1>;
-    type Output = xdevs::Port<usize, 1>;
+impl crate::Component for AtomicModel {
+    type Kind = crate::AtomicKind;
+    type Input = crate::Port<usize, 1>;
+    type Output = crate::Port<usize, 1>;
 }
 
-impl xdevs::Atomic for AtomicModel {
+impl crate::Atomic for AtomicModel {
     fn delta_int(&mut self) {
         self.sigma = f64::INFINITY;
         self.n_internals += 1;
@@ -161,15 +161,15 @@ impl Devstone for AtomicModel {
 }
 
 /// Leaf coupled model with only one atomic in LI models and HI leaf model
-#[xdevs::coupled]
+#[crate::coupled]
 pub struct LeafModel {
     atomic: AtomicModel,
 }
 
-impl xdevs::Component for LeafModel {
-    type Kind = xdevs::CoupledKind;
-    type Input = xdevs::Port<usize, 1>;
-    type Output = xdevs::Port<usize, 1>;
+impl crate::Component for LeafModel {
+    type Kind = crate::CoupledKind;
+    type Input = crate::Port<usize, 1>;
+    type Output = crate::Port<usize, 1>;
 }
 
 impl LeafModel {
@@ -206,11 +206,11 @@ impl Default for LeafModel {
     }
 }
 
-impl xdevs::Coupled for LeafModel {
-    fn eic(from: &Self::Input, to: &mut xdevs::ComponentsInput<Self>) {
+impl crate::Coupled for LeafModel {
+    fn eic(from: &Self::Input, to: &mut crate::ComponentsInput<Self>) {
         let _ = from.couple(&mut to.atomic);
     }
-    fn eoc(from: &xdevs::ComponentsOutput<Self>, to: &mut Self::Output) {
+    fn eoc(from: &crate::ComponentsOutput<Self>, to: &mut Self::Output) {
         let _ = from.atomic.couple(to);
     }
 }
@@ -337,13 +337,13 @@ macro_rules! impl_devstone_top {
 #[cfg(test)]
 mod test {
     use super::*;
-    use xdevs::Atomic;
+    use crate::Atomic;
 
     #[test]
     fn job_generator_emits_configured_count() {
         let gen = JobGenerator::new(5);
 
-        let mut output = <JobGenerator as xdevs::Component>::Output::default();
+        let mut output = <JobGenerator as crate::Component>::Output::default();
         gen.lambda(&mut output);
         assert_eq!(
             output.get_values(),

--- a/src/devstone/common.rs
+++ b/src/devstone/common.rs
@@ -1,6 +1,9 @@
-use crate::Duration;
 #[cfg(not(feature = "std"))]
 use crate::Instant;
+use crate::{
+    Atomic, AtomicKind, Component, ComponentsInput, ComponentsOutput, Coupled, CoupledKind,
+    Duration, Port,
+};
 #[cfg(feature = "std")]
 use cpu_time::ThreadTime;
 
@@ -10,13 +13,13 @@ pub struct JobGenerator {
     count: usize,
 }
 
-impl crate::Component for JobGenerator {
-    type Kind = crate::AtomicKind;
+impl Component for JobGenerator {
+    type Kind = AtomicKind;
     type Input = ();
-    type Output = crate::Port<usize, 1>;
+    type Output = Port<usize, 1>;
 }
 
-impl crate::Atomic for JobGenerator {
+impl Atomic for JobGenerator {
     fn delta_int(&mut self) {
         self.sigma = f64::INFINITY;
     }
@@ -75,13 +78,13 @@ fn burn_cycles(duration: Duration) {
     }
 }
 
-impl crate::Component for AtomicModel {
-    type Kind = crate::AtomicKind;
-    type Input = crate::Port<usize, 1>;
-    type Output = crate::Port<usize, 1>;
+impl Component for AtomicModel {
+    type Kind = AtomicKind;
+    type Input = Port<usize, 1>;
+    type Output = Port<usize, 1>;
 }
 
-impl crate::Atomic for AtomicModel {
+impl Atomic for AtomicModel {
     fn delta_int(&mut self) {
         self.sigma = f64::INFINITY;
         self.n_internals += 1;
@@ -166,10 +169,10 @@ pub struct LeafModel {
     atomic: AtomicModel,
 }
 
-impl crate::Component for LeafModel {
-    type Kind = crate::CoupledKind;
-    type Input = crate::Port<usize, 1>;
-    type Output = crate::Port<usize, 1>;
+impl Component for LeafModel {
+    type Kind = CoupledKind;
+    type Input = Port<usize, 1>;
+    type Output = Port<usize, 1>;
 }
 
 impl LeafModel {
@@ -206,11 +209,11 @@ impl Default for LeafModel {
     }
 }
 
-impl crate::Coupled for LeafModel {
-    fn eic(from: &Self::Input, to: &mut crate::ComponentsInput<Self>) {
+impl Coupled for LeafModel {
+    fn eic(from: &Self::Input, to: &mut ComponentsInput<Self>) {
         let _ = from.couple(&mut to.atomic);
     }
-    fn eoc(from: &crate::ComponentsOutput<Self>, to: &mut Self::Output) {
+    fn eoc(from: &ComponentsOutput<Self>, to: &mut Self::Output) {
         let _ = from.atomic.couple(to);
     }
 }
@@ -337,13 +340,13 @@ macro_rules! impl_devstone_top {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::Atomic;
+    use Atomic;
 
     #[test]
     fn job_generator_emits_configured_count() {
         let gen = JobGenerator::new(5);
 
-        let mut output = <JobGenerator as crate::Component>::Output::default();
+        let mut output = <JobGenerator as Component>::Output::default();
         gen.lambda(&mut output);
         assert_eq!(
             output.get_values(),

--- a/src/devstone/hi.rs
+++ b/src/devstone/hi.rs
@@ -1,6 +1,5 @@
 use super::common::{AtomicModel, Devstone, JobGenerator, LeafModel};
-use crate::Component;
-
+use crate::{Component, ComponentsInput, ComponentsOutput, Coupled, CoupledKind, Port};
 /// HI model enum (ref version)
 #[crate::to_component]
 pub enum HIEnum<'a, const W: usize> {
@@ -19,14 +18,14 @@ pub struct HIModel<'a, const W: usize> {
     inner: &'a mut HIEnum<'a, W>,
 }
 
-impl<'a, const W: usize> crate::Component for HIModel<'a, W> {
-    type Kind = crate::CoupledKind;
-    type Input = crate::Port<usize, 1>;
-    type Output = crate::Port<usize, 1>;
+impl<'a, const W: usize> Component for HIModel<'a, W> {
+    type Kind = CoupledKind;
+    type Input = Port<usize, 1>;
+    type Output = Port<usize, 1>;
 }
 
-impl<'a, const W: usize> crate::Coupled for HIModel<'a, W> {
-    fn eic(from: &Self::Input, to: &mut crate::ComponentsInput<Self>) {
+impl<'a, const W: usize> Coupled for HIModel<'a, W> {
+    fn eic(from: &Self::Input, to: &mut ComponentsInput<Self>) {
         for atom_ports in to.atomics.iter_mut() {
             let _ = from.couple(atom_ports);
         }
@@ -34,11 +33,11 @@ impl<'a, const W: usize> crate::Coupled for HIModel<'a, W> {
         let _ = from.couple(&mut to.inner);
     }
 
-    fn eoc(from: &crate::ComponentsOutput<Self>, to: &mut Self::Output) {
+    fn eoc(from: &ComponentsOutput<Self>, to: &mut Self::Output) {
         let _ = from.inner.couple(to);
     }
 
-    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
+    fn ic(from: &ComponentsOutput<Self>, to: &mut ComponentsInput<Self>) {
         for i in 0..(W.saturating_sub(1)) {
             let _ = from.atomics[i].couple(&mut to.atomics[i + 1]);
         }
@@ -66,17 +65,17 @@ pub struct TopModel<'a, const W: usize> {
 }
 
 impl<'a, const W: usize> Component for TopModel<'a, W> {
-    type Kind = crate::CoupledKind;
-    type Input = crate::Port<usize, 1>;
-    type Output = crate::Port<usize, 1>;
+    type Kind = CoupledKind;
+    type Input = Port<usize, 1>;
+    type Output = Port<usize, 1>;
 }
 
 impl<'a, const W: usize> Devstone for TopModel<'a, W> {
     crate::impl_devstone_top!(hi_model, generator);
 }
 
-impl<'a, const W: usize> crate::Coupled for TopModel<'a, W> {
-    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
+impl<'a, const W: usize> Coupled for TopModel<'a, W> {
+    fn ic(from: &ComponentsOutput<Self>, to: &mut ComponentsInput<Self>) {
         let _ = from.generator.couple(&mut to.hi_model);
     }
 }
@@ -105,7 +104,7 @@ mod test {
         let generator = JobGenerator::new(5);
         let top_model: TopModel<'_, W> = TopModel::build(generator, &mut model_hi);
         let mut simulator = top_model.to_simulator();
-        let config = crate::simulation::Config::new(0.0, 10.0, 1.0, None);
+        let config = crate::Config::new(0.0, 10.0, 1.0, None);
         simulator.simulate_vt(&config);
 
         assert_eq!(expected_n_atomic(WIDTH, DEPTH), simulator.get_n_atomics());

--- a/src/devstone/hi.rs
+++ b/src/devstone/hi.rs
@@ -84,7 +84,7 @@ impl<'a, const W: usize> crate::Coupled for TopModel<'a, W> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::simulation::AbstractSimulator;
+    use crate::prelude::*;
 
     fn expected_n_atomic(width: usize, depth: usize) -> usize {
         (width - 1) * (depth - 1) + 1
@@ -96,7 +96,6 @@ mod test {
 
     #[test]
     fn simulation_matches_expected_counts_and_resets() {
-        use crate::simulation::Simulable;
         const WIDTH: usize = 10;
         const DEPTH: usize = 10;
         const W: usize = WIDTH - 1;

--- a/src/devstone/hi_box.rs
+++ b/src/devstone/hi_box.rs
@@ -3,7 +3,7 @@ use crate::Component;
 use alloc::boxed::Box;
 
 /// HI model enum
-#[xdevs::to_component]
+#[crate::to_component]
 pub enum HIEnum<const W: usize> {
     Leaf(LeafModel),
     Branch(HIModel<W>),
@@ -14,20 +14,20 @@ impl<const W: usize> Devstone for HIEnum<W> {
 }
 
 /// HI coupled model
-#[xdevs::coupled]
+#[crate::coupled]
 pub struct HIModel<const W: usize> {
     atomics: [AtomicModel; W],
     inner: Box<HIEnum<W>>,
 }
 
-impl<const W: usize> xdevs::Component for HIModel<W> {
-    type Kind = xdevs::CoupledKind;
-    type Input = xdevs::Port<usize, 1>;
-    type Output = xdevs::Port<usize, 1>;
+impl<const W: usize> crate::Component for HIModel<W> {
+    type Kind = crate::CoupledKind;
+    type Input = crate::Port<usize, 1>;
+    type Output = crate::Port<usize, 1>;
 }
 
-impl<const W: usize> xdevs::Coupled for HIModel<W> {
-    fn eic(from: &Self::Input, to: &mut xdevs::ComponentsInput<Self>) {
+impl<const W: usize> crate::Coupled for HIModel<W> {
+    fn eic(from: &Self::Input, to: &mut crate::ComponentsInput<Self>) {
         for atom_ports in to.atomics.iter_mut() {
             let _ = from.couple(atom_ports);
         }
@@ -35,11 +35,11 @@ impl<const W: usize> xdevs::Coupled for HIModel<W> {
         let _ = from.couple(&mut to.inner);
     }
 
-    fn eoc(from: &xdevs::ComponentsOutput<Self>, to: &mut Self::Output) {
+    fn eoc(from: &crate::ComponentsOutput<Self>, to: &mut Self::Output) {
         let _ = from.inner.couple(to);
     }
 
-    fn ic(from: &xdevs::ComponentsOutput<Self>, to: &mut xdevs::ComponentsInput<Self>) {
+    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
         for i in 0..(W.saturating_sub(1)) {
             let _ = from.atomics[i].couple(&mut to.atomics[i + 1]);
         }
@@ -60,23 +60,23 @@ impl<const W: usize> Devstone for HIModel<W> {
 }
 
 /// End model with Generator and HI model coupled together
-#[xdevs::coupled]
+#[crate::coupled]
 pub struct TopModel<const W: usize> {
     generator: JobGenerator,
     hi_model: HIEnum<W>,
 }
 
 impl<const W: usize> Component for TopModel<W> {
-    type Kind = xdevs::CoupledKind;
-    type Input = xdevs::Port<usize, 1>;
-    type Output = xdevs::Port<usize, 1>;
+    type Kind = crate::CoupledKind;
+    type Input = crate::Port<usize, 1>;
+    type Output = crate::Port<usize, 1>;
 }
 impl<const W: usize> Devstone for TopModel<W> {
     crate::impl_devstone_top!(hi_model, generator);
 }
 
-impl<const W: usize> xdevs::Coupled for TopModel<W> {
-    fn ic(from: &xdevs::ComponentsOutput<Self>, to: &mut xdevs::ComponentsInput<Self>) {
+impl<const W: usize> crate::Coupled for TopModel<W> {
+    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
         let _ = from.generator.couple(&mut to.hi_model);
     }
 }
@@ -84,7 +84,7 @@ impl<const W: usize> xdevs::Coupled for TopModel<W> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use xdevs::prelude::*;
+    use crate::prelude::*;
 
     fn expected_n_atomic(width: usize, depth: usize) -> usize {
         (width - 1) * (depth - 1) + 1
@@ -100,12 +100,12 @@ mod test {
         const DEPTH: usize = 10;
         const W: usize = WIDTH - 1;
 
-        xdevs::generate_hi_box!(10, 10, 0, 0);
+        crate::generate_hi_box!(10, 10, 0, 0);
 
         let generator = JobGenerator::new(5);
         let top_model: TopModel<W> = TopModel::build(generator, model_hi);
         let mut simulator = top_model.to_simulator();
-        let config = xdevs::Config::new(0.0, 10.0, 1.0, None);
+        let config = crate::Config::new(0.0, 10.0, 1.0, None);
         simulator.simulate_vt(&config);
 
         assert_eq!(expected_n_atomic(WIDTH, DEPTH), simulator.get_n_atomics());

--- a/src/devstone/hi_box.rs
+++ b/src/devstone/hi_box.rs
@@ -84,6 +84,7 @@ impl<const W: usize> xdevs::Coupled for TopModel<W> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use xdevs::prelude::*;
 
     fn expected_n_atomic(width: usize, depth: usize) -> usize {
         (width - 1) * (depth - 1) + 1
@@ -95,8 +96,6 @@ mod test {
 
     #[test]
     fn simulation_matches_expected_counts_and_resets() {
-        use xdevs::{AbstractSimulator, Simulable};
-
         const WIDTH: usize = 10;
         const DEPTH: usize = 10;
         const W: usize = WIDTH - 1;

--- a/src/devstone/hi_box.rs
+++ b/src/devstone/hi_box.rs
@@ -1,5 +1,5 @@
 use super::common::{AtomicModel, Devstone, JobGenerator, LeafModel};
-use crate::Component;
+use crate::{Component, ComponentsInput, ComponentsOutput, Coupled, CoupledKind, Port};
 use alloc::boxed::Box;
 
 /// HI model enum
@@ -20,14 +20,14 @@ pub struct HIModel<const W: usize> {
     inner: Box<HIEnum<W>>,
 }
 
-impl<const W: usize> crate::Component for HIModel<W> {
-    type Kind = crate::CoupledKind;
-    type Input = crate::Port<usize, 1>;
-    type Output = crate::Port<usize, 1>;
+impl<const W: usize> Component for HIModel<W> {
+    type Kind = CoupledKind;
+    type Input = Port<usize, 1>;
+    type Output = Port<usize, 1>;
 }
 
-impl<const W: usize> crate::Coupled for HIModel<W> {
-    fn eic(from: &Self::Input, to: &mut crate::ComponentsInput<Self>) {
+impl<const W: usize> Coupled for HIModel<W> {
+    fn eic(from: &Self::Input, to: &mut ComponentsInput<Self>) {
         for atom_ports in to.atomics.iter_mut() {
             let _ = from.couple(atom_ports);
         }
@@ -35,11 +35,11 @@ impl<const W: usize> crate::Coupled for HIModel<W> {
         let _ = from.couple(&mut to.inner);
     }
 
-    fn eoc(from: &crate::ComponentsOutput<Self>, to: &mut Self::Output) {
+    fn eoc(from: &ComponentsOutput<Self>, to: &mut Self::Output) {
         let _ = from.inner.couple(to);
     }
 
-    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
+    fn ic(from: &ComponentsOutput<Self>, to: &mut ComponentsInput<Self>) {
         for i in 0..(W.saturating_sub(1)) {
             let _ = from.atomics[i].couple(&mut to.atomics[i + 1]);
         }
@@ -67,16 +67,16 @@ pub struct TopModel<const W: usize> {
 }
 
 impl<const W: usize> Component for TopModel<W> {
-    type Kind = crate::CoupledKind;
-    type Input = crate::Port<usize, 1>;
-    type Output = crate::Port<usize, 1>;
+    type Kind = CoupledKind;
+    type Input = Port<usize, 1>;
+    type Output = Port<usize, 1>;
 }
 impl<const W: usize> Devstone for TopModel<W> {
     crate::impl_devstone_top!(hi_model, generator);
 }
 
-impl<const W: usize> crate::Coupled for TopModel<W> {
-    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
+impl<const W: usize> Coupled for TopModel<W> {
+    fn ic(from: &ComponentsOutput<Self>, to: &mut ComponentsInput<Self>) {
         let _ = from.generator.couple(&mut to.hi_model);
     }
 }

--- a/src/devstone/ho.rs
+++ b/src/devstone/ho.rs
@@ -5,8 +5,8 @@ use super::common::{AtomicModel, Devstone, JobGenerator};
 /// Output struct for HO models (ref version)
 #[derive(Debug, Default, crate::Bag)]
 pub struct HOModelOutput<const W: usize> {
-    output_port_1: xdevs::Port<usize, 1>,
-    output_port_2: xdevs::Port<usize, W>,
+    output_port_1: crate::Port<usize, 1>,
+    output_port_2: crate::Port<usize, W>,
 }
 
 /// Leaf coupled model with only one atomic in HO models (ref version)

--- a/src/devstone/ho.rs
+++ b/src/devstone/ho.rs
@@ -1,12 +1,11 @@
-use crate::Component;
-
 use super::common::{AtomicModel, Devstone, JobGenerator};
+use crate::{Component, ComponentsInput, ComponentsOutput, Coupled, CoupledKind, Port};
 
 /// Output struct for HO models (ref version)
 #[derive(Debug, Default, crate::Bag)]
 pub struct HOModelOutput<const W: usize> {
-    output_port_1: crate::Port<usize, 1>,
-    output_port_2: crate::Port<usize, W>,
+    output_port_1: Port<usize, 1>,
+    output_port_2: Port<usize, W>,
 }
 
 /// Leaf coupled model with only one atomic in HO models (ref version)
@@ -15,17 +14,17 @@ pub struct LeafModel<const W: usize> {
     atomic: AtomicModel,
 }
 
-impl<const W: usize> crate::Component for LeafModel<W> {
-    type Kind = crate::CoupledKind;
-    type Input = crate::Port<usize, 1>;
+impl<const W: usize> Component for LeafModel<W> {
+    type Kind = CoupledKind;
+    type Input = Port<usize, 1>;
     type Output = HOModelOutput<W>;
 }
 
-impl<const W: usize> crate::Coupled for LeafModel<W> {
-    fn eic(from: &Self::Input, to: &mut crate::ComponentsInput<Self>) {
+impl<const W: usize> Coupled for LeafModel<W> {
+    fn eic(from: &Self::Input, to: &mut ComponentsInput<Self>) {
         let _ = from.couple(&mut to.atomic);
     }
-    fn eoc(from: &crate::ComponentsOutput<Self>, to: &mut Self::Output) {
+    fn eoc(from: &ComponentsOutput<Self>, to: &mut Self::Output) {
         let _ = from.atomic.couple(&mut to.output_port_1);
     }
 }
@@ -77,28 +76,28 @@ impl<'a, const W: usize> Devstone for HOModel<'a, W> {
     crate::impl_devstone_coupled!();
 }
 
-impl<'a, const W: usize> crate::Component for HOModel<'a, W> {
-    type Kind = crate::CoupledKind;
-    type Input = crate::Port<usize, 1>;
+impl<'a, const W: usize> Component for HOModel<'a, W> {
+    type Kind = CoupledKind;
+    type Input = Port<usize, 1>;
     type Output = HOModelOutput<W>;
 }
 
-impl<'a, const W: usize> crate::Coupled for HOModel<'a, W> {
-    fn eic(from: &Self::Input, to: &mut crate::ComponentsInput<Self>) {
+impl<'a, const W: usize> Coupled for HOModel<'a, W> {
+    fn eic(from: &Self::Input, to: &mut ComponentsInput<Self>) {
         let _ = from.couple(&mut to.inner);
         for atom_ports in to.atomics.iter_mut() {
             let _ = from.couple(atom_ports);
         }
     }
 
-    fn eoc(from: &crate::ComponentsOutput<Self>, to: &mut Self::Output) {
+    fn eoc(from: &ComponentsOutput<Self>, to: &mut Self::Output) {
         let _ = from.inner.output_port_1.couple(&mut to.output_port_1);
         for atom_output_ports in from.atomics.iter() {
             let _ = atom_output_ports.couple(&mut to.output_port_2);
         }
     }
 
-    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
+    fn ic(from: &ComponentsOutput<Self>, to: &mut ComponentsInput<Self>) {
         for i in 0..(W.saturating_sub(1)) {
             let _ = from.atomics[i].couple(&mut to.atomics[i + 1]);
         }
@@ -113,17 +112,17 @@ pub struct TopModel<'a, const W: usize> {
 }
 
 impl<'a, const W: usize> Component for TopModel<'a, W> {
-    type Kind = crate::CoupledKind;
-    type Input = crate::Port<usize, 1>;
-    type Output = crate::Port<usize, 1>;
+    type Kind = CoupledKind;
+    type Input = Port<usize, 1>;
+    type Output = Port<usize, 1>;
 }
 
 impl<'a, const W: usize> Devstone for TopModel<'a, W> {
     crate::impl_devstone_top!(ho_model, generator);
 }
 
-impl<'a, const W: usize> crate::Coupled for TopModel<'a, W> {
-    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
+impl<'a, const W: usize> Coupled for TopModel<'a, W> {
+    fn ic(from: &ComponentsOutput<Self>, to: &mut ComponentsInput<Self>) {
         let _ = from.generator.couple(&mut to.ho_model);
     }
 }
@@ -152,7 +151,7 @@ mod test {
         let generator = JobGenerator::new(5);
         let top_model: TopModel<'_, W> = TopModel::build(generator, &mut model_ho);
         let mut simulator = top_model.to_simulator();
-        let config = crate::simulation::Config::new(0.0, 10.0, 1.0, None);
+        let config = crate::Config::new(0.0, 10.0, 1.0, None);
         simulator.simulate_vt(&config);
 
         assert_eq!(expected_n_atomic(WIDTH, DEPTH), simulator.get_n_atomics());

--- a/src/devstone/ho.rs
+++ b/src/devstone/ho.rs
@@ -131,7 +131,7 @@ impl<'a, const W: usize> crate::Coupled for TopModel<'a, W> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::simulation::AbstractSimulator;
+    use crate::prelude::*;
 
     fn expected_n_atomic(width: usize, depth: usize) -> usize {
         (width - 1) * (depth - 1) + 1
@@ -143,7 +143,6 @@ mod test {
 
     #[test]
     fn simulation_matches_expected_counts_and_resets() {
-        use crate::simulation::Simulable;
         const WIDTH: usize = 10;
         const DEPTH: usize = 10;
         const W: usize = WIDTH - 1;

--- a/src/devstone/ho_box.rs
+++ b/src/devstone/ho_box.rs
@@ -129,6 +129,7 @@ impl<const W: usize> xdevs::Coupled for TopModel<W> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use xdevs::prelude::*;
 
     fn expected_n_atomic(width: usize, depth: usize) -> usize {
         (width - 1) * (depth - 1) + 1
@@ -140,8 +141,6 @@ mod test {
 
     #[test]
     fn simulation_matches_expected_counts_and_resets() {
-        use xdevs::{AbstractSimulator, Simulable};
-
         const WIDTH: usize = 10;
         const DEPTH: usize = 10;
         const W: usize = WIDTH - 1;

--- a/src/devstone/ho_box.rs
+++ b/src/devstone/ho_box.rs
@@ -1,12 +1,12 @@
 use super::common::{AtomicModel, Devstone, JobGenerator};
-use crate::Component;
+use crate::{Component, ComponentsInput, ComponentsOutput, Coupled, CoupledKind, Port};
 use alloc::boxed::Box;
 
 /// Output struct for HO models
 #[derive(Debug, Default, crate::Bag)]
 pub struct HOModelOutput<const W: usize> {
-    pub output_port_1: crate::Port<usize, 1>,
-    pub output_port_2: crate::Port<usize, W>,
+    pub output_port_1: Port<usize, 1>,
+    pub output_port_2: Port<usize, W>,
 }
 
 /// Leaf coupled model with only one atomic in HO models
@@ -15,17 +15,17 @@ pub struct LeafModel<const W: usize> {
     atomic: AtomicModel,
 }
 
-impl<const W: usize> crate::Component for LeafModel<W> {
-    type Kind = crate::CoupledKind;
-    type Input = crate::Port<usize, 1>;
+impl<const W: usize> Component for LeafModel<W> {
+    type Kind = CoupledKind;
+    type Input = Port<usize, 1>;
     type Output = HOModelOutput<W>;
 }
 
-impl<const W: usize> crate::Coupled for LeafModel<W> {
-    fn eic(from: &Self::Input, to: &mut crate::ComponentsInput<Self>) {
+impl<const W: usize> Coupled for LeafModel<W> {
+    fn eic(from: &Self::Input, to: &mut ComponentsInput<Self>) {
         let _ = from.couple(&mut to.atomic);
     }
-    fn eoc(from: &crate::ComponentsOutput<Self>, to: &mut Self::Output) {
+    fn eoc(from: &ComponentsOutput<Self>, to: &mut Self::Output) {
         let _ = from.atomic.couple(&mut to.output_port_1);
     }
 }
@@ -75,28 +75,28 @@ impl<const W: usize> HOModel<W> {
 impl<const W: usize> Devstone for HOModel<W> {
     crate::impl_devstone_coupled!();
 }
-impl<const W: usize> crate::Component for HOModel<W> {
-    type Kind = crate::CoupledKind;
-    type Input = crate::Port<usize, 1>;
+impl<const W: usize> Component for HOModel<W> {
+    type Kind = CoupledKind;
+    type Input = Port<usize, 1>;
     type Output = HOModelOutput<W>;
 }
 
-impl<const W: usize> crate::Coupled for HOModel<W> {
-    fn eic(from: &Self::Input, to: &mut crate::ComponentsInput<Self>) {
+impl<const W: usize> Coupled for HOModel<W> {
+    fn eic(from: &Self::Input, to: &mut ComponentsInput<Self>) {
         let _ = from.couple(&mut to.inner);
         for atom_ports in to.atomics.iter_mut() {
             let _ = from.couple(atom_ports);
         }
     }
 
-    fn eoc(from: &crate::ComponentsOutput<Self>, to: &mut Self::Output) {
+    fn eoc(from: &ComponentsOutput<Self>, to: &mut Self::Output) {
         let _ = from.inner.output_port_1.couple(&mut to.output_port_1);
         for atom_output_ports in from.atomics.iter() {
             let _ = atom_output_ports.couple(&mut to.output_port_2);
         }
     }
 
-    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
+    fn ic(from: &ComponentsOutput<Self>, to: &mut ComponentsInput<Self>) {
         for i in 0..(W.saturating_sub(1)) {
             let _ = from.atomics[i].couple(&mut to.atomics[i + 1]);
         }
@@ -111,17 +111,17 @@ pub struct TopModel<const W: usize> {
 }
 
 impl<const W: usize> Component for TopModel<W> {
-    type Kind = crate::CoupledKind;
-    type Input = crate::Port<usize, 1>;
-    type Output = crate::Port<usize, 1>;
+    type Kind = CoupledKind;
+    type Input = Port<usize, 1>;
+    type Output = Port<usize, 1>;
 }
 
 impl<const W: usize> Devstone for TopModel<W> {
     crate::impl_devstone_top!(ho_model, generator);
 }
 
-impl<const W: usize> crate::Coupled for TopModel<W> {
-    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
+impl<const W: usize> Coupled for TopModel<W> {
+    fn ic(from: &ComponentsOutput<Self>, to: &mut ComponentsInput<Self>) {
         let _ = from.generator.couple(&mut to.ho_model);
     }
 }

--- a/src/devstone/ho_box.rs
+++ b/src/devstone/ho_box.rs
@@ -1,31 +1,31 @@
 use super::common::{AtomicModel, Devstone, JobGenerator};
+use crate::Component;
 use alloc::boxed::Box;
-use xdevs::Component;
 
 /// Output struct for HO models
-#[derive(Debug, Default, xdevs::Bag)]
+#[derive(Debug, Default, crate::Bag)]
 pub struct HOModelOutput<const W: usize> {
-    pub output_port_1: xdevs::Port<usize, 1>,
-    pub output_port_2: xdevs::Port<usize, W>,
+    pub output_port_1: crate::Port<usize, 1>,
+    pub output_port_2: crate::Port<usize, W>,
 }
 
 /// Leaf coupled model with only one atomic in HO models
-#[xdevs::coupled]
+#[crate::coupled]
 pub struct LeafModel<const W: usize> {
     atomic: AtomicModel,
 }
 
-impl<const W: usize> xdevs::Component for LeafModel<W> {
-    type Kind = xdevs::CoupledKind;
-    type Input = xdevs::Port<usize, 1>;
+impl<const W: usize> crate::Component for LeafModel<W> {
+    type Kind = crate::CoupledKind;
+    type Input = crate::Port<usize, 1>;
     type Output = HOModelOutput<W>;
 }
 
-impl<const W: usize> xdevs::Coupled for LeafModel<W> {
-    fn eic(from: &Self::Input, to: &mut xdevs::ComponentsInput<Self>) {
+impl<const W: usize> crate::Coupled for LeafModel<W> {
+    fn eic(from: &Self::Input, to: &mut crate::ComponentsInput<Self>) {
         let _ = from.couple(&mut to.atomic);
     }
-    fn eoc(from: &xdevs::ComponentsOutput<Self>, to: &mut Self::Output) {
+    fn eoc(from: &crate::ComponentsOutput<Self>, to: &mut Self::Output) {
         let _ = from.atomic.couple(&mut to.output_port_1);
     }
 }
@@ -47,7 +47,7 @@ impl<const W: usize> Devstone for LeafModel<W> {
 }
 
 /// HO model enum
-#[xdevs::to_component]
+#[crate::to_component]
 pub enum HOEnum<const W: usize> {
     Leaf(LeafModel<W>),
     Branch(HOModel<W>),
@@ -58,7 +58,7 @@ impl<const W: usize> Devstone for HOEnum<W> {
 }
 
 /// HO coupled model
-#[xdevs::coupled]
+#[crate::coupled]
 pub struct HOModel<const W: usize> {
     atomics: [AtomicModel; W],
     inner: Box<HOEnum<W>>,
@@ -75,28 +75,28 @@ impl<const W: usize> HOModel<W> {
 impl<const W: usize> Devstone for HOModel<W> {
     crate::impl_devstone_coupled!();
 }
-impl<const W: usize> xdevs::Component for HOModel<W> {
-    type Kind = xdevs::CoupledKind;
-    type Input = xdevs::Port<usize, 1>;
+impl<const W: usize> crate::Component for HOModel<W> {
+    type Kind = crate::CoupledKind;
+    type Input = crate::Port<usize, 1>;
     type Output = HOModelOutput<W>;
 }
 
-impl<const W: usize> xdevs::Coupled for HOModel<W> {
-    fn eic(from: &Self::Input, to: &mut xdevs::ComponentsInput<Self>) {
+impl<const W: usize> crate::Coupled for HOModel<W> {
+    fn eic(from: &Self::Input, to: &mut crate::ComponentsInput<Self>) {
         let _ = from.couple(&mut to.inner);
         for atom_ports in to.atomics.iter_mut() {
             let _ = from.couple(atom_ports);
         }
     }
 
-    fn eoc(from: &xdevs::ComponentsOutput<Self>, to: &mut Self::Output) {
+    fn eoc(from: &crate::ComponentsOutput<Self>, to: &mut Self::Output) {
         let _ = from.inner.output_port_1.couple(&mut to.output_port_1);
         for atom_output_ports in from.atomics.iter() {
             let _ = atom_output_ports.couple(&mut to.output_port_2);
         }
     }
 
-    fn ic(from: &xdevs::ComponentsOutput<Self>, to: &mut xdevs::ComponentsInput<Self>) {
+    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
         for i in 0..(W.saturating_sub(1)) {
             let _ = from.atomics[i].couple(&mut to.atomics[i + 1]);
         }
@@ -104,24 +104,24 @@ impl<const W: usize> xdevs::Coupled for HOModel<W> {
 }
 
 /// End model with Generator and HO model coupled together
-#[xdevs::coupled]
+#[crate::coupled]
 pub struct TopModel<const W: usize> {
     generator: JobGenerator,
     ho_model: HOEnum<W>,
 }
 
 impl<const W: usize> Component for TopModel<W> {
-    type Kind = xdevs::CoupledKind;
-    type Input = xdevs::Port<usize, 1>;
-    type Output = xdevs::Port<usize, 1>;
+    type Kind = crate::CoupledKind;
+    type Input = crate::Port<usize, 1>;
+    type Output = crate::Port<usize, 1>;
 }
 
 impl<const W: usize> Devstone for TopModel<W> {
     crate::impl_devstone_top!(ho_model, generator);
 }
 
-impl<const W: usize> xdevs::Coupled for TopModel<W> {
-    fn ic(from: &xdevs::ComponentsOutput<Self>, to: &mut xdevs::ComponentsInput<Self>) {
+impl<const W: usize> crate::Coupled for TopModel<W> {
+    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
         let _ = from.generator.couple(&mut to.ho_model);
     }
 }
@@ -129,7 +129,7 @@ impl<const W: usize> xdevs::Coupled for TopModel<W> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use xdevs::prelude::*;
+    use crate::prelude::*;
 
     fn expected_n_atomic(width: usize, depth: usize) -> usize {
         (width - 1) * (depth - 1) + 1
@@ -145,12 +145,12 @@ mod test {
         const DEPTH: usize = 10;
         const W: usize = WIDTH - 1;
 
-        xdevs::generate_ho_box!(10, 10, 0, 0);
+        crate::generate_ho_box!(10, 10, 0, 0);
 
         let generator = JobGenerator::new(5);
         let top_model: TopModel<W> = TopModel::build(generator, model_ho);
         let mut simulator = top_model.to_simulator();
-        let config = xdevs::Config::new(0.0, 10.0, 1.0, None);
+        let config = crate::Config::new(0.0, 10.0, 1.0, None);
         simulator.simulate_vt(&config);
 
         assert_eq!(expected_n_atomic(WIDTH, DEPTH), simulator.get_n_atomics());

--- a/src/devstone/li.rs
+++ b/src/devstone/li.rs
@@ -78,7 +78,7 @@ impl<'a, const W: usize> crate::Coupled for TopModel<'a, W> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::simulation::AbstractSimulator;
+    use crate::prelude::*;
 
     fn expected_n_atomic(width: usize, depth: usize) -> usize {
         (width - 1) * (depth - 1) + 1
@@ -90,7 +90,6 @@ mod test {
 
     #[test]
     fn simulation_matches_expected_counts_and_resets() {
-        use crate::simulation::Simulable;
         const WIDTH: usize = 10;
         const DEPTH: usize = 10;
         const W: usize = WIDTH - 1;

--- a/src/devstone/li.rs
+++ b/src/devstone/li.rs
@@ -1,6 +1,5 @@
 use super::common::{AtomicModel, Devstone, JobGenerator, LeafModel};
-use crate::Component;
-
+use crate::{Component, ComponentsInput, ComponentsOutput, Coupled, CoupledKind, Port};
 /// LI model enum (ref version)
 #[crate::to_component]
 pub enum LIEnum<'a, const W: usize> {
@@ -19,14 +18,14 @@ pub struct LIModel<'a, const W: usize> {
     inner: &'a mut LIEnum<'a, W>,
 }
 
-impl<'a, const W: usize> crate::Component for LIModel<'a, W> {
-    type Kind = crate::CoupledKind;
-    type Input = crate::Port<usize, 1>;
-    type Output = crate::Port<usize, 1>;
+impl<'a, const W: usize> Component for LIModel<'a, W> {
+    type Kind = CoupledKind;
+    type Input = Port<usize, 1>;
+    type Output = Port<usize, 1>;
 }
 
-impl<'a, const W: usize> crate::Coupled for LIModel<'a, W> {
-    fn eic(from: &Self::Input, to: &mut crate::ComponentsInput<Self>) {
+impl<'a, const W: usize> Coupled for LIModel<'a, W> {
+    fn eic(from: &Self::Input, to: &mut ComponentsInput<Self>) {
         for atom_ports in to.atomics.iter_mut() {
             let _ = from.couple(atom_ports);
         }
@@ -34,7 +33,7 @@ impl<'a, const W: usize> crate::Coupled for LIModel<'a, W> {
         let _ = from.couple(&mut to.inner);
     }
 
-    fn eoc(from: &crate::ComponentsOutput<Self>, to: &mut Self::Output) {
+    fn eoc(from: &ComponentsOutput<Self>, to: &mut Self::Output) {
         let _ = from.inner.couple(to);
     }
 }
@@ -60,7 +59,7 @@ pub struct TopModel<'a, const W: usize> {
 }
 
 impl<'a, const W: usize> Component for TopModel<'a, W> {
-    type Kind = crate::CoupledKind;
+    type Kind = CoupledKind;
     type Input = ();
     type Output = ();
 }
@@ -69,8 +68,8 @@ impl<'a, const W: usize> Devstone for TopModel<'a, W> {
     crate::impl_devstone_top!(li_model, generator);
 }
 
-impl<'a, const W: usize> crate::Coupled for TopModel<'a, W> {
-    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
+impl<'a, const W: usize> Coupled for TopModel<'a, W> {
+    fn ic(from: &ComponentsOutput<Self>, to: &mut ComponentsInput<Self>) {
         let _ = from.generator.couple(&mut to.li_model);
     }
 }
@@ -99,7 +98,7 @@ mod test {
         let generator = JobGenerator::new(5);
         let top_model: TopModel<'_, W> = TopModel::build(generator, &mut model_li);
         let mut simulator = top_model.to_simulator();
-        let config = crate::simulation::Config::new(0.0, 10.0, 1.0, None);
+        let config = crate::Config::new(0.0, 10.0, 1.0, None);
         simulator.simulate_vt(&config);
 
         assert_eq!(expected_n_atomic(WIDTH, DEPTH), simulator.get_n_atomics());

--- a/src/devstone/li_box.rs
+++ b/src/devstone/li_box.rs
@@ -1,8 +1,8 @@
 use super::common::{AtomicModel, Devstone, JobGenerator, LeafModel};
+use crate::Component;
 use alloc::boxed::Box;
-use xdevs::Component;
 
-#[xdevs::to_component]
+#[crate::to_component]
 pub enum LIEnum<const W: usize> {
     Leaf(LeafModel),
     Branch(LIModel<W>),
@@ -13,20 +13,20 @@ impl<const W: usize> Devstone for LIEnum<W> {
 }
 
 /// LI coupled model
-#[xdevs::coupled]
+#[crate::coupled]
 pub struct LIModel<const W: usize> {
     atomics: [AtomicModel; W],
     inner: Box<LIEnum<W>>,
 }
 
 impl<const W: usize> Component for LIModel<W> {
-    type Kind = xdevs::CoupledKind;
-    type Input = xdevs::Port<usize, 1>;
-    type Output = xdevs::Port<usize, 1>;
+    type Kind = crate::CoupledKind;
+    type Input = crate::Port<usize, 1>;
+    type Output = crate::Port<usize, 1>;
 }
 
-impl<const W: usize> xdevs::Coupled for LIModel<W> {
-    fn eic(from: &Self::Input, to: &mut xdevs::ComponentsInput<Self>) {
+impl<const W: usize> crate::Coupled for LIModel<W> {
+    fn eic(from: &Self::Input, to: &mut crate::ComponentsInput<Self>) {
         for atom_ports in to.atomics.iter_mut() {
             let _ = from.couple(atom_ports);
         }
@@ -34,7 +34,7 @@ impl<const W: usize> xdevs::Coupled for LIModel<W> {
         let _ = from.couple(&mut to.inner);
     }
 
-    fn eoc(from: &xdevs::ComponentsOutput<Self>, to: &mut Self::Output) {
+    fn eoc(from: &crate::ComponentsOutput<Self>, to: &mut Self::Output) {
         let _ = from.inner.couple(to);
     }
 }
@@ -53,14 +53,14 @@ impl<const W: usize> Devstone for LIModel<W> {
 }
 
 /// End model with Generator and LI model coupled together
-#[xdevs::coupled]
+#[crate::coupled]
 pub struct TopModel<const W: usize> {
     generator: JobGenerator,
     li_model: LIEnum<W>,
 }
 
 impl<const W: usize> Component for TopModel<W> {
-    type Kind = xdevs::CoupledKind;
+    type Kind = crate::CoupledKind;
     type Input = ();
     type Output = ();
 }
@@ -69,8 +69,8 @@ impl<const W: usize> Devstone for TopModel<W> {
     crate::impl_devstone_top!(li_model, generator);
 }
 
-impl<const W: usize> xdevs::Coupled for TopModel<W> {
-    fn ic(from: &xdevs::ComponentsOutput<Self>, to: &mut xdevs::ComponentsInput<Self>) {
+impl<const W: usize> crate::Coupled for TopModel<W> {
+    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
         let _ = from.generator.couple(&mut to.li_model);
     }
 }
@@ -78,7 +78,7 @@ impl<const W: usize> xdevs::Coupled for TopModel<W> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use xdevs::prelude::*;
+    use crate::prelude::*;
 
     fn expected_n_atomic(width: usize, depth: usize) -> usize {
         (width - 1) * (depth - 1) + 1
@@ -94,12 +94,12 @@ mod test {
         const DEPTH: usize = 10;
         const W: usize = WIDTH - 1;
 
-        xdevs::generate_li_box!(10, 10, 0, 0);
+        crate::generate_li_box!(10, 10, 0, 0);
 
         let generator = JobGenerator::new(5);
         let top_model: TopModel<W> = TopModel::build(generator, model_li);
         let mut simulator = top_model.to_simulator();
-        let config = xdevs::Config::new(0.0, 10.0, 1.0, None);
+        let config = crate::Config::new(0.0, 10.0, 1.0, None);
         simulator.simulate_vt(&config);
 
         assert_eq!(expected_n_atomic(WIDTH, DEPTH), simulator.get_n_atomics());

--- a/src/devstone/li_box.rs
+++ b/src/devstone/li_box.rs
@@ -1,5 +1,5 @@
 use super::common::{AtomicModel, Devstone, JobGenerator, LeafModel};
-use crate::Component;
+use crate::{Component, ComponentsInput, ComponentsOutput, Coupled, CoupledKind, Port};
 use alloc::boxed::Box;
 
 #[crate::to_component]
@@ -20,13 +20,13 @@ pub struct LIModel<const W: usize> {
 }
 
 impl<const W: usize> Component for LIModel<W> {
-    type Kind = crate::CoupledKind;
-    type Input = crate::Port<usize, 1>;
-    type Output = crate::Port<usize, 1>;
+    type Kind = CoupledKind;
+    type Input = Port<usize, 1>;
+    type Output = Port<usize, 1>;
 }
 
-impl<const W: usize> crate::Coupled for LIModel<W> {
-    fn eic(from: &Self::Input, to: &mut crate::ComponentsInput<Self>) {
+impl<const W: usize> Coupled for LIModel<W> {
+    fn eic(from: &Self::Input, to: &mut ComponentsInput<Self>) {
         for atom_ports in to.atomics.iter_mut() {
             let _ = from.couple(atom_ports);
         }
@@ -34,7 +34,7 @@ impl<const W: usize> crate::Coupled for LIModel<W> {
         let _ = from.couple(&mut to.inner);
     }
 
-    fn eoc(from: &crate::ComponentsOutput<Self>, to: &mut Self::Output) {
+    fn eoc(from: &ComponentsOutput<Self>, to: &mut Self::Output) {
         let _ = from.inner.couple(to);
     }
 }
@@ -60,7 +60,7 @@ pub struct TopModel<const W: usize> {
 }
 
 impl<const W: usize> Component for TopModel<W> {
-    type Kind = crate::CoupledKind;
+    type Kind = CoupledKind;
     type Input = ();
     type Output = ();
 }
@@ -69,8 +69,8 @@ impl<const W: usize> Devstone for TopModel<W> {
     crate::impl_devstone_top!(li_model, generator);
 }
 
-impl<const W: usize> crate::Coupled for TopModel<W> {
-    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
+impl<const W: usize> Coupled for TopModel<W> {
+    fn ic(from: &ComponentsOutput<Self>, to: &mut ComponentsInput<Self>) {
         let _ = from.generator.couple(&mut to.li_model);
     }
 }

--- a/src/devstone/li_box.rs
+++ b/src/devstone/li_box.rs
@@ -78,6 +78,8 @@ impl<const W: usize> xdevs::Coupled for TopModel<W> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use xdevs::prelude::*;
+
     fn expected_n_atomic(width: usize, depth: usize) -> usize {
         (width - 1) * (depth - 1) + 1
     }
@@ -88,8 +90,6 @@ mod test {
 
     #[test]
     fn simulation_matches_expected_counts_and_resets() {
-        use xdevs::{AbstractSimulator, Simulable};
-
         const WIDTH: usize = 10;
         const DEPTH: usize = 10;
         const W: usize = WIDTH - 1;

--- a/src/gpt.rs
+++ b/src/gpt.rs
@@ -1,3 +1,6 @@
+use crate::{
+    Atomic, AtomicKind, Component, ComponentsInput, ComponentsOutput, Coupled, CoupledKind, Port,
+};
 /// Generator that produces jobs at a fixed period until told to stop.
 pub struct Generator {
     sigma: f64,
@@ -5,13 +8,13 @@ pub struct Generator {
     count: usize,
 }
 
-impl crate::Component for Generator {
-    type Kind = crate::AtomicKind;
-    type Input = crate::Port<bool, 1>;
-    type Output = crate::Port<usize, 1>;
+impl Component for Generator {
+    type Kind = AtomicKind;
+    type Input = Port<bool, 1>;
+    type Output = Port<usize, 1>;
 }
 
-impl crate::Atomic for Generator {
+impl Atomic for Generator {
     fn delta_int(&mut self) {
         self.count += 1;
         self.sigma = self.period;
@@ -56,13 +59,13 @@ pub struct Processor {
     job: Option<usize>,
 }
 
-impl crate::Component for Processor {
-    type Kind = crate::AtomicKind;
-    type Input = crate::Port<usize, 1>;
-    type Output = crate::Port<usize, 1>;
+impl Component for Processor {
+    type Kind = AtomicKind;
+    type Input = Port<usize, 1>;
+    type Output = Port<usize, 1>;
 }
 
-impl crate::Atomic for Processor {
+impl Atomic for Processor {
     fn delta_int(&mut self) {
         self.sigma = f64::INFINITY;
         if self.job.is_some() {
@@ -113,8 +116,8 @@ impl Processor {
 /// Input bag for the Transducer.
 #[derive(crate::Bag)]
 pub struct TransducerInput {
-    pub in_generator: crate::Port<usize, 1>,
-    pub in_processor: crate::Port<usize, 1>,
+    pub in_generator: Port<usize, 1>,
+    pub in_processor: Port<usize, 1>,
 }
 
 /// Transducer that observes generated and processed jobs, computes metrics,
@@ -126,13 +129,13 @@ pub struct Transducer {
     n_processed: usize,
 }
 
-impl crate::Component for Transducer {
-    type Kind = crate::AtomicKind;
+impl Component for Transducer {
+    type Kind = AtomicKind;
     type Input = TransducerInput;
-    type Output = crate::Port<bool, 1>;
+    type Output = Port<bool, 1>;
 }
 
-impl crate::Atomic for Transducer {
+impl Atomic for Transducer {
     fn delta_int(&mut self) {
         self.clock += self.sigma;
         #[cfg(feature = "std")]
@@ -194,14 +197,14 @@ pub struct GPT {
     transducer: Transducer,
 }
 
-impl crate::Component for GPT {
-    type Kind = crate::CoupledKind;
+impl Component for GPT {
+    type Kind = CoupledKind;
     type Input = ();
     type Output = ();
 }
 
-impl crate::Coupled for GPT {
-    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
+impl Coupled for GPT {
+    fn ic(from: &ComponentsOutput<Self>, to: &mut ComponentsInput<Self>) {
         from.generator.couple(&mut to.processor).unwrap();
         from.processor
             .couple(&mut to.transducer.in_processor)
@@ -219,23 +222,23 @@ pub struct EF {
     transducer: Transducer,
 }
 
-impl crate::Component for EF {
-    type Kind = crate::CoupledKind;
-    type Input = crate::Port<usize, 1>;
-    type Output = crate::Port<usize, 1>;
+impl Component for EF {
+    type Kind = CoupledKind;
+    type Input = Port<usize, 1>;
+    type Output = Port<usize, 1>;
 }
 
-impl crate::Coupled for EF {
-    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
+impl Coupled for EF {
+    fn ic(from: &ComponentsOutput<Self>, to: &mut ComponentsInput<Self>) {
         from.generator
             .couple(&mut to.transducer.in_generator)
             .unwrap();
         from.transducer.couple(&mut to.generator).unwrap();
     }
-    fn eic(from: &Self::Input, to: &mut crate::ComponentsInput<Self>) {
+    fn eic(from: &Self::Input, to: &mut ComponentsInput<Self>) {
         from.couple(&mut to.transducer.in_processor).unwrap();
     }
-    fn eoc(from: &crate::ComponentsOutput<Self>, to: &mut Self::Output) {
+    fn eoc(from: &ComponentsOutput<Self>, to: &mut Self::Output) {
         from.generator.couple(to).unwrap();
     }
 }
@@ -246,14 +249,14 @@ pub struct EFP {
     processor: Processor,
 }
 
-impl crate::Component for EFP {
-    type Kind = crate::CoupledKind;
+impl Component for EFP {
+    type Kind = CoupledKind;
     type Input = ();
     type Output = ();
 }
 
-impl crate::Coupled for EFP {
-    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
+impl Coupled for EFP {
+    fn ic(from: &ComponentsOutput<Self>, to: &mut ComponentsInput<Self>) {
         from.ef.couple(&mut to.processor).unwrap();
         from.processor.couple(&mut to.ef).unwrap();
     }
@@ -262,10 +265,7 @@ impl crate::Coupled for EFP {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::port::Bag;
-    use crate::prelude::*;
-    use crate::simulation::Config;
-    use crate::{Atomic, Component};
+    use crate::{port::Bag, prelude::*, Atomic, Component, Config};
 
     #[test]
     fn generator_emits_sequential_jobs() {

--- a/src/gpt.rs
+++ b/src/gpt.rs
@@ -263,7 +263,8 @@ impl xdevs::Coupled for EFP {
 mod tests {
     use super::*;
     use crate::port::Bag;
-    use crate::simulation::{AbstractSimulator, Config, Simulable};
+    use crate::prelude::*;
+    use crate::simulation::Config;
     use crate::{Atomic, Component};
 
     #[test]

--- a/src/gpt.rs
+++ b/src/gpt.rs
@@ -5,13 +5,13 @@ pub struct Generator {
     count: usize,
 }
 
-impl xdevs::Component for Generator {
-    type Kind = xdevs::AtomicKind;
-    type Input = xdevs::Port<bool, 1>;
-    type Output = xdevs::Port<usize, 1>;
+impl crate::Component for Generator {
+    type Kind = crate::AtomicKind;
+    type Input = crate::Port<bool, 1>;
+    type Output = crate::Port<usize, 1>;
 }
 
-impl xdevs::Atomic for Generator {
+impl crate::Atomic for Generator {
     fn delta_int(&mut self) {
         self.count += 1;
         self.sigma = self.period;
@@ -56,13 +56,13 @@ pub struct Processor {
     job: Option<usize>,
 }
 
-impl xdevs::Component for Processor {
-    type Kind = xdevs::AtomicKind;
-    type Input = xdevs::Port<usize, 1>;
-    type Output = xdevs::Port<usize, 1>;
+impl crate::Component for Processor {
+    type Kind = crate::AtomicKind;
+    type Input = crate::Port<usize, 1>;
+    type Output = crate::Port<usize, 1>;
 }
 
-impl xdevs::Atomic for Processor {
+impl crate::Atomic for Processor {
     fn delta_int(&mut self) {
         self.sigma = f64::INFINITY;
         if self.job.is_some() {
@@ -111,10 +111,10 @@ impl Processor {
 }
 
 /// Input bag for the Transducer.
-#[derive(xdevs::Bag)]
+#[derive(crate::Bag)]
 pub struct TransducerInput {
-    pub in_generator: xdevs::Port<usize, 1>,
-    pub in_processor: xdevs::Port<usize, 1>,
+    pub in_generator: crate::Port<usize, 1>,
+    pub in_processor: crate::Port<usize, 1>,
 }
 
 /// Transducer that observes generated and processed jobs, computes metrics,
@@ -126,13 +126,13 @@ pub struct Transducer {
     n_processed: usize,
 }
 
-impl xdevs::Component for Transducer {
-    type Kind = xdevs::AtomicKind;
+impl crate::Component for Transducer {
+    type Kind = crate::AtomicKind;
     type Input = TransducerInput;
-    type Output = xdevs::Port<bool, 1>;
+    type Output = crate::Port<bool, 1>;
 }
 
-impl xdevs::Atomic for Transducer {
+impl crate::Atomic for Transducer {
     fn delta_int(&mut self) {
         self.clock += self.sigma;
         #[cfg(feature = "std")]
@@ -187,21 +187,21 @@ impl Transducer {
     }
 }
 
-#[xdevs::coupled]
+#[crate::coupled]
 pub struct GPT {
     generator: Generator,
     processor: Processor,
     transducer: Transducer,
 }
 
-impl xdevs::Component for GPT {
-    type Kind = xdevs::CoupledKind;
+impl crate::Component for GPT {
+    type Kind = crate::CoupledKind;
     type Input = ();
     type Output = ();
 }
 
-impl xdevs::Coupled for GPT {
-    fn ic(from: &xdevs::ComponentsOutput<Self>, to: &mut xdevs::ComponentsInput<Self>) {
+impl crate::Coupled for GPT {
+    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
         from.generator.couple(&mut to.processor).unwrap();
         from.processor
             .couple(&mut to.transducer.in_processor)
@@ -213,47 +213,47 @@ impl xdevs::Coupled for GPT {
     }
 }
 
-#[xdevs::coupled]
+#[crate::coupled]
 pub struct EF {
     generator: Generator,
     transducer: Transducer,
 }
 
-impl xdevs::Component for EF {
-    type Kind = xdevs::CoupledKind;
-    type Input = xdevs::Port<usize, 1>;
-    type Output = xdevs::Port<usize, 1>;
+impl crate::Component for EF {
+    type Kind = crate::CoupledKind;
+    type Input = crate::Port<usize, 1>;
+    type Output = crate::Port<usize, 1>;
 }
 
-impl xdevs::Coupled for EF {
-    fn ic(from: &xdevs::ComponentsOutput<Self>, to: &mut xdevs::ComponentsInput<Self>) {
+impl crate::Coupled for EF {
+    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
         from.generator
             .couple(&mut to.transducer.in_generator)
             .unwrap();
         from.transducer.couple(&mut to.generator).unwrap();
     }
-    fn eic(from: &Self::Input, to: &mut xdevs::ComponentsInput<Self>) {
+    fn eic(from: &Self::Input, to: &mut crate::ComponentsInput<Self>) {
         from.couple(&mut to.transducer.in_processor).unwrap();
     }
-    fn eoc(from: &xdevs::ComponentsOutput<Self>, to: &mut Self::Output) {
+    fn eoc(from: &crate::ComponentsOutput<Self>, to: &mut Self::Output) {
         from.generator.couple(to).unwrap();
     }
 }
 
-#[xdevs::coupled]
+#[crate::coupled]
 pub struct EFP {
     ef: EF,
     processor: Processor,
 }
 
-impl xdevs::Component for EFP {
-    type Kind = xdevs::CoupledKind;
+impl crate::Component for EFP {
+    type Kind = crate::CoupledKind;
     type Input = ();
     type Output = ();
 }
 
-impl xdevs::Coupled for EFP {
-    fn ic(from: &xdevs::ComponentsOutput<Self>, to: &mut xdevs::ComponentsInput<Self>) {
+impl crate::Coupled for EFP {
+    fn ic(from: &crate::ComponentsOutput<Self>, to: &mut crate::ComponentsInput<Self>) {
         from.ef.couple(&mut to.processor).unwrap();
         from.processor.couple(&mut to.ef).unwrap();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,5 +21,14 @@ pub use component::{
 };
 pub use embassy_time::{Duration, Instant};
 pub use port::Port;
-pub use simulation::{AbstractSimulator, Config, Simulable};
+pub use simulation::Config;
 pub use xdevs_no_std_macros::*;
+
+/// Prelude with the traits needed to call the high-level simulation methods
+/// (`.to_simulator()`, `.simulate_vt()`, `.simulate_rt()`, `.simulate_rt_async()`)
+/// directly on components and simulators.
+///
+/// Intended to be imported with `use xdevs::prelude::*;`.
+pub mod prelude {
+    pub use crate::simulation::{AbstractSimulator, Simulable};
+}

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -369,108 +369,101 @@ unsafe impl<T: AbstractSimulator> AbstractSimulator for Option<T> {
     }
 }
 
-// Splitter that deinterleaves a list of tts into even-indexed and odd-indexed halves.
 #[cfg(feature = "rayon")]
-macro_rules! split_even_odd {
+mod tuple_macros {
+    // Splitter that deinterleaves a list of tts into even-indexed and odd-indexed halves.
+    macro_rules! split_even_odd {
     ([$($even:tt)*] [$($odd:tt)*] [] $cont:ident $ctx:tt) => {
-        $cont!([$($even)*] [$($odd)*] $ctx)
+        tuple_macros::$cont!([$($even)*] [$($odd)*] $ctx)
     };
     ([$($even:tt)*] [$($odd:tt)*] [$a:tt] $cont:ident $ctx:tt) => {
-        $cont!([$($even)* $a] [$($odd)*] $ctx)
+        tuple_macros::$cont!([$($even)* $a] [$($odd)*] $ctx)
     };
     ([$($even:tt)*] [$($odd:tt)*] [$a:tt $b:tt $($rest:tt)*] $cont:ident $ctx:tt) => {
-        split_even_odd!([$($even)* $a] [$($odd)* $b] [$($rest)*] $cont $ctx)
+        tuple_macros::split_even_odd!([$($even)* $a] [$($odd)* $b] [$($rest)*] $cont $ctx)
     };
 }
 
-// Balanced rayon::join tree for tuple start (returns f64::min).
-#[cfg(feature = "rayon")]
-macro_rules! par_start {
+    // Balanced rayon::join tree for tuple start (returns f64::min).
+    macro_rules! par_start {
     ($self:expr, $t:expr, [$idx:tt]) => {
         $crate::simulation::AbstractSimulator::start(&mut $self.$idx, $t)
     };
     ($self:expr, $t:expr, [$idx:tt $($rest:tt)+]) => {
-        split_even_odd!([] [] [$idx $($rest)+] par_start_node [$self, $t])
+        tuple_macros::split_even_odd!([] [] [$idx $($rest)+] par_start_node [$self, $t])
     };
 }
 
-#[cfg(feature = "rayon")]
-macro_rules! par_start_node {
+    macro_rules! par_start_node {
     ([$($even:tt)*] [$($odd:tt)*] [$self:expr, $t:expr]) => {{
         let (a, b) = ::rayon::join(
-            || par_start!($self, $t, [$($even)*]),
-            || par_start!($self, $t, [$($odd)*]),
+            || tuple_macros::par_start!($self, $t, [$($even)*]),
+            || tuple_macros::par_start!($self, $t, [$($odd)*]),
         );
         f64::min(a, b)
     }};
 }
 
-// Balanced rayon::join tree for tuple stop (returns ()).
-#[cfg(feature = "rayon")]
-macro_rules! par_stop {
+    // Balanced rayon::join tree for tuple stop (returns ()).
+    macro_rules! par_stop {
     ($self:expr, [$idx:tt]) => {
         $crate::simulation::AbstractSimulator::stop(&mut $self.$idx)
     };
     ($self:expr, [$idx:tt $($rest:tt)+]) => {
-        split_even_odd!([] [] [$idx $($rest)+] par_stop_node [$self])
+        tuple_macros::split_even_odd!([] [] [$idx $($rest)+] par_stop_node [$self])
     };
 }
 
-#[cfg(feature = "rayon")]
-macro_rules! par_stop_node {
+    macro_rules! par_stop_node {
     ([$($even:tt)*] [$($odd:tt)*] [$self:expr]) => {{
         ::rayon::join(
-            || par_stop!($self, [$($even)*]),
-            || par_stop!($self, [$($odd)*]),
+            || tuple_macros::par_stop!($self, [$($even)*]),
+            || tuple_macros::par_stop!($self, [$($odd)*]),
         );
     }};
 }
 
-// Balanced rayon::join tree for tuple lambda (returns ()).
-#[cfg(feature = "rayon")]
-macro_rules! par_lambda {
+    // Balanced rayon::join tree for tuple lambda (returns ()).
+    macro_rules! par_lambda {
     ($self:expr, $output:expr, $t:expr, [$idx:tt]) => {
         $crate::simulation::AbstractSimulator::lambda(&mut $self.$idx, &mut $output.$idx, $t)
     };
     ($self:expr, $output:expr, $t:expr, [$idx:tt $($rest:tt)+]) => {
-        split_even_odd!([] [] [$idx $($rest)+] par_lambda_node [$self, $output, $t])
+        tuple_macros::split_even_odd!([] [] [$idx $($rest)+] par_lambda_node [$self, $output, $t])
     };
 }
 
-#[cfg(feature = "rayon")]
-macro_rules! par_lambda_node {
+    macro_rules! par_lambda_node {
     ([$($even:tt)*] [$($odd:tt)*] [$self:expr, $output:expr, $t:expr]) => {{
         ::rayon::join(
-            || par_lambda!($self, $output, $t, [$($even)*]),
-            || par_lambda!($self, $output, $t, [$($odd)*]),
+            || tuple_macros::par_lambda!($self, $output, $t, [$($even)*]),
+            || tuple_macros::par_lambda!($self, $output, $t, [$($odd)*]),
         );
     }};
 }
 
-// Balanced rayon::join tree for tuple delta (returns f64::min).
-#[cfg(feature = "rayon")]
-macro_rules! par_delta {
+    // Balanced rayon::join tree for tuple delta (returns f64::min).
+    macro_rules! par_delta {
     ($self:expr, $input:expr, $output:expr, $t:expr, [$idx:tt]) => {
         $crate::simulation::AbstractSimulator::delta(
             &mut $self.$idx, &mut $input.$idx, &mut $output.$idx, $t)
     };
     ($self:expr, $input:expr, $output:expr, $t:expr, [$idx:tt $($rest:tt)+]) => {
-        split_even_odd!([] [] [$idx $($rest)+] par_delta_node [$self, $input, $output, $t])
+        tuple_macros::split_even_odd!([] [] [$idx $($rest)+] par_delta_node [$self, $input, $output, $t])
     };
 }
 
-#[cfg(feature = "rayon")]
-macro_rules! par_delta_node {
+    macro_rules! par_delta_node {
     ([$($even:tt)*] [$($odd:tt)*] [$self:expr, $input:expr, $output:expr, $t:expr]) => {{
         let (a, b) = ::rayon::join(
-            || par_delta!($self, $input, $output, $t, [$($even)*]),
-            || par_delta!($self, $input, $output, $t, [$($odd)*]),
+            || tuple_macros::par_delta!($self, $input, $output, $t, [$($even)*]),
+            || tuple_macros::par_delta!($self, $input, $output, $t, [$($odd)*]),
         );
         f64::min(a, b)
     }};
 }
 
-macro_rules! impl_abstract_simulator_for_tuple {
+    macro_rules! impl_abstract_simulator_for_tuple {
     ($($idx:tt => $T:ident),+) => {
         unsafe impl<$($T: AbstractSimulator + SimSend),+> AbstractSimulator for ($($T,)+)
         where
@@ -481,71 +474,92 @@ macro_rules! impl_abstract_simulator_for_tuple {
 
             #[inline(always)]
             fn start(&mut self, t_start: f64) -> f64 {
-                #[cfg(feature = "rayon")]
-                {
-                    par_start!(self, t_start, [$($idx)+])
-                }
-                #[cfg(not(feature = "rayon"))]
-                {
-                    let mut min_t = f64::INFINITY;
-                    $(min_t = min_t.min(self.$idx.start(t_start));)+
-                    min_t
-                }
+                tuple_macros::par_start!(self, t_start, [$($idx)+])
             }
 
             #[inline(always)]
             fn stop(&mut self) {
-                #[cfg(feature = "rayon")]
-                {
-                    par_stop!(self, [$($idx)+])
-                }
-                #[cfg(not(feature = "rayon"))]
-                {
-                    $(self.$idx.stop();)+
-                }
+                tuple_macros::par_stop!(self, [$($idx)+])
             }
 
             #[inline(always)]
             fn lambda(&mut self, output: &mut Self::Output, t: f64) {
-                #[cfg(feature = "rayon")]
-                {
-                    par_lambda!(self, output, t, [$($idx)+])
-                }
-                #[cfg(not(feature = "rayon"))]
-                {
-                    $(self.$idx.lambda(&mut output.$idx, t);)+
-                }
+                tuple_macros::par_lambda!(self, output, t, [$($idx)+])
             }
 
             #[inline(always)]
             fn delta(&mut self, input: &mut Self::Input, output: &mut Self::Output, t: f64) -> f64 {
-                #[cfg(feature = "rayon")]
-                {
-                    par_delta!(self, input, output, t, [$($idx)+])
-                }
-                #[cfg(not(feature = "rayon"))]
-                {
-                    let mut min_t = f64::INFINITY;
-                    $(min_t = min_t.min(self.$idx.delta(&mut input.$idx, &mut output.$idx, t));)+
-                    min_t
-                }
+                tuple_macros::par_delta!(self, input, output, t, [$($idx)+])
+            }
+        }
+    }
+    }
+    pub(crate) use impl_abstract_simulator_for_tuple;
+    pub(crate) use par_delta;
+    pub(crate) use par_delta_node;
+    pub(crate) use par_lambda;
+    pub(crate) use par_lambda_node;
+    pub(crate) use par_start;
+    pub(crate) use par_start_node;
+    pub(crate) use par_stop;
+    pub(crate) use par_stop_node;
+    pub(crate) use split_even_odd;
+}
+
+#[cfg(not(feature = "rayon"))]
+mod tuple_macros {
+    macro_rules! impl_abstract_simulator_for_tuple {
+    ($($idx:tt => $T:ident),+) => {
+        unsafe impl<$($T: AbstractSimulator + SimSend),+> AbstractSimulator for ($($T,)+)
+        where
+            $($T::Input: SimSend, $T::Output: SimSend),+
+        {
+            type Input = ($($T::Input,)+);
+            type Output = ($($T::Output,)+);
+
+            #[inline(always)]
+            fn start(&mut self, t_start: f64) -> f64 {
+                let mut min_t = f64::INFINITY;
+                $(min_t = min_t.min(self.$idx.start(t_start));)+
+                min_t
+
+            }
+
+            #[inline(always)]
+            fn stop(&mut self) {
+                $(self.$idx.stop();)+
+
+            }
+
+            #[inline(always)]
+            fn lambda(&mut self, output: &mut Self::Output, t: f64) {
+                $(self.$idx.lambda(&mut output.$idx, t);)+
+            }
+
+            #[inline(always)]
+            fn delta(&mut self, input: &mut Self::Input, output: &mut Self::Output, t: f64) -> f64 {
+                let mut min_t = f64::INFINITY;
+                $(min_t = min_t.min(self.$idx.delta(&mut input.$idx, &mut output.$idx, t));)+
+                min_t
             }
         }
     }
 }
+    pub(crate) use impl_abstract_simulator_for_tuple;
+}
 
-impl_abstract_simulator_for_tuple!(0 => T0);
-impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1);
-impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2);
-impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3);
-impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4);
-impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5);
-impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6);
-impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7);
-impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8);
-impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9);
-impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10);
-impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10, 11 => T11);
+tuple_macros::impl_abstract_simulator_for_tuple!(0 => T0);
+tuple_macros::impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1);
+tuple_macros::impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2);
+tuple_macros::impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3);
+tuple_macros::impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4);
+tuple_macros::impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5);
+tuple_macros::impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6);
+tuple_macros::impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7);
+tuple_macros::impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8);
+tuple_macros::impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9);
+tuple_macros::impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10);
+tuple_macros::impl_abstract_simulator_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10, 11 => T11);
 
 macro_rules! impl_simulable_for_tuple {
     ($($idx:tt => ($T:ident, $K:ident)),+) => {

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,4 +1,4 @@
-use crate::{component::Component, port::Bag, ComponentsKind};
+use crate::{port::Bag, Component, ComponentsKind};
 use core::{future::Future, time::Duration};
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
@@ -640,10 +640,8 @@ where
 #[cfg(test)]
 pub(crate) mod test_utils {
     use crate::{
-        component::coupled::{ComponentsInput, ComponentsOutput, Coupled},
-        component::CoupledKind,
-        port::Port,
-        Atomic, AtomicKind, Component,
+        port::Port, Atomic, AtomicKind, Component, ComponentsInput, ComponentsOutput, Coupled,
+        CoupledKind,
     };
 
     pub(crate) struct TestAtomic {
@@ -1127,10 +1125,7 @@ mod tests {
     #[test]
     fn simulate_vt_with_array() {
         // Coupled model with array of atomics
-        use crate::component::{
-            coupled::{ComponentsInput, ComponentsOutput, Coupled},
-            CoupledKind,
-        };
+        use crate::{ComponentsInput, ComponentsOutput, Coupled, CoupledKind};
 
         #[crate::to_component]
         struct ArrayCoupledComponents {

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -730,7 +730,8 @@ mod tests {
     use crate::{
         component::coupled::PartialCoupled,
         port::Port,
-        simulation::{simulator::Simulator, AbstractSimulator, Config, Simulable},
+        prelude::*,
+        simulation::{simulator::Simulator, Config},
         Component,
     };
     #[test]

--- a/src/simulation/coordinator.rs
+++ b/src/simulation/coordinator.rs
@@ -1,10 +1,7 @@
 use crate::{
-    component::{
-        coupled::{ComponentsInput, ComponentsOutput, Coupled},
-        CoupledKind,
-    },
     port::Bag,
     simulation::{AbstractSimulator, Simulable},
+    ComponentsInput, ComponentsOutput, Coupled, CoupledKind,
 };
 use core::ops::{Deref, DerefMut};
 

--- a/src/simulation/simulator.rs
+++ b/src/simulation/simulator.rs
@@ -1,7 +1,7 @@
 use crate::{
-    component::{atomic::Atomic, AtomicKind},
     port::Bag,
     simulation::{AbstractSimulator, Simulable},
+    Atomic, AtomicKind,
 };
 use core::ops::{Deref, DerefMut};
 


### PR DESCRIPTION
The main change of this PR is the addition of a prelude module with the traits that the user needs to import in order to use the simulation methods with no problems.

Minor changes have been done to tuple macros to group them together and reduce the number of #[cfg] within the code.

Finally, the DEVStone models have been changed in order for all of them to use xdevs:: for their paths. Before, they were alternating between xdevs:: and crate::. I think this change can be good if we want these models to also work as illustrative examples for the users.