### PR TITLE
BagMux for Port, arrays and tuples

### DIFF
--- a/examples/gpt_enum.rs
+++ b/examples/gpt_enum.rs
@@ -8,7 +8,7 @@ use xdevs::{
 };
 
 mod processor {
-    use xdevs::{AtomicKind, Port};
+    use xdevs::{prelude::*, AtomicKind, Port};
 
     pub struct FastProcessor {
         sigma: f64,

--- a/examples/rt_engine.rs
+++ b/examples/rt_engine.rs
@@ -3,12 +3,12 @@
 /// would look like for an input array.
 use xdevs::{AtomicKind, Config, Port};
 
-#[derive(xdevs::Bag, xdevs::AsPort)]
+#[derive(xdevs::Bag)]
 pub struct TransparentInput {
     pub in_job: [Port<usize, 1>; 3],
 }
 
-#[derive(xdevs::Bag, xdevs::AsPort)]
+#[derive(xdevs::Bag)]
 pub struct TransparentOutput {
     pub out_job: Port<usize, 1>,
 }

--- a/examples/rt_engine.rs
+++ b/examples/rt_engine.rs
@@ -1,7 +1,7 @@
 /// This example demonstrates how the rt_engine can be used to simplify the DEVS simulation
 /// interaction with other tasks. An array is used for the input to showcase how the input enum
 /// would look like for an input array.
-use xdevs::{AtomicKind, Config, Port};
+use xdevs::{prelude::*, AtomicKind, Config, Port};
 
 #[derive(xdevs::Bag)]
 pub struct TransparentInput {

--- a/examples/rt_engine.rs
+++ b/examples/rt_engine.rs
@@ -3,12 +3,12 @@
 /// would look like for an input array.
 use xdevs::{AtomicKind, Config, Port};
 
-#[derive(xdevs::Bag, xdevs::BagMux)]
+#[derive(xdevs::Bag, xdevs::AsPort)]
 pub struct TransparentInput {
     pub in_job: [Port<usize, 1>; 3],
 }
 
-#[derive(xdevs::Bag, xdevs::BagMux)]
+#[derive(xdevs::Bag, xdevs::AsPort)]
 pub struct TransparentOutput {
     pub out_job: Port<usize, 1>,
 }

--- a/macros/src/derive.rs
+++ b/macros/src/derive.rs
@@ -1,10 +1,15 @@
 use heck::ToSnakeCase;
 use heck::ToUpperCamelCase;
 use proc_macro2::TokenStream as TokenStream2;
-use syn::{Data, DeriveInput, Error, Fields, Ident, Index, Result};
+use syn::{Data, DeriveInput, Error, Fields, Ident, Result};
 
 pub fn derive_bag(input: DeriveInput) -> Result<TokenStream2> {
     let ident = input.ident;
+    let snake_case_ident = Ident::new(&ident.to_string().to_snake_case(), ident.span());
+    let private_mod_ident = Ident::new(
+        &format!("_xdevs_no_std_{}_bag", snake_case_ident),
+        ident.span(),
+    );
     let generics = input.generics;
 
     let fields = match input.data {
@@ -17,123 +22,61 @@ pub fn derive_bag(input: DeriveInput) -> Result<TokenStream2> {
         }
     };
 
-    let accesses: Vec<TokenStream2> = match &fields {
-        Fields::Named(fields) => fields
-            .named
-            .iter()
-            .map(|field| {
-                let field_ident = field.ident.as_ref().expect("named field must have ident");
-                quote::quote!(self.#field_ident)
-            })
-            .collect(),
-        Fields::Unnamed(fields) => fields
-            .unnamed
-            .iter()
-            .enumerate()
-            .map(|(i, _)| {
-                let index = Index::from(i);
-                quote::quote!(self.#index)
-            })
-            .collect(),
-        Fields::Unit => Vec::new(),
-    };
-
-    let build_body = match &fields {
-        Fields::Named(fields) => {
-            let build_fields = fields.named.iter().map(|field| {
-                let field_ident = field.ident.as_ref().expect("named field must have ident");
-                let field_ty = &field.ty;
-                quote::quote!(#field_ident: <#field_ty as ::xdevs::port::Bag>::build())
-            });
-            quote::quote! {
-                Self {
-                    #(#build_fields),*
-                }
-            }
-        }
-        Fields::Unnamed(fields) => {
-            let build_elems = fields.unnamed.iter().map(|field| {
-                let field_ty = &field.ty;
-                quote::quote!(<#field_ty as ::xdevs::port::Bag>::build())
-            });
-            quote::quote! {
-                Self(
-                    #(#build_elems),*
-                )
-            }
-        }
-        Fields::Unit => quote::quote! { Self },
-    };
-
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-
-    let is_empty_body = if accesses.is_empty() {
-        quote::quote! {
-            true
-        }
-    } else {
-        quote::quote! {
-            #(#accesses.is_empty())&&*
-        }
-    };
-
-    Ok(quote::quote! {
-        unsafe impl #impl_generics ::xdevs::port::Bag for #ident #ty_generics #where_clause {
-            #[inline]
-            fn build() -> Self {
-                #build_body
-            }
-
-            #[inline]
-            fn is_empty(&self) -> bool {
-                #is_empty_body
-            }
-
-            #[inline]
-            fn clear(&mut self) {
-                #( #accesses.clear(); )*
-            }
-        }
-    })
-}
-
-pub fn derive_asport(input: DeriveInput) -> Result<TokenStream2> {
-    let ident = input.ident;
-    let snake_case_ident = Ident::new(&ident.to_string().to_snake_case(), ident.span());
-    let private_mod_ident = Ident::new(
-        &format!("_xdevs_no_std_{}_asport", snake_case_ident),
-        ident.span(),
-    );
-    let generics = input.generics;
-
-    let fields = match input.data {
-        Data::Struct(data) => data.fields,
-        _ => {
-            return Err(Error::new_spanned(
-                ident,
-                "AsPort can only be derived for structs",
-            ))
-        }
-    };
-
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     match fields {
         Fields::Unnamed(_) => Err(Error::new_spanned(
             ident,
-            "AsPort cannot be derived for tuple structs",
+            "Bag cannot be derived for tuple structs",
         )),
         Fields::Unit => Ok(quote::quote! {
-            unsafe impl #impl_generics ::xdevs::port::AsPort for #ident #ty_generics #where_clause {
+            unsafe impl #impl_generics ::xdevs::port::Bag for #ident #ty_generics #where_clause {
                 type Value = ();
+
+                #[inline]
+                fn build() -> Self {
+                    Self
+                }
+
+                #[inline]
+                fn is_empty(&self) -> bool {
+                    true
+                }
+
+                #[inline]
+                fn clear(&mut self) {}
+
+                #[inline]
                 fn inject_event(&mut self, _event: Self::Value) -> ::core::result::Result<(), Self::Value> {
                     Ok(())
                 }
+
+                #[inline]
                 fn eject_events(&self, _ejector: impl FnMut(Self::Value)) {}
             }
         }),
-
         Fields::Named(fields) => {
+            let accesses: Vec<TokenStream2> = fields
+                .named
+                .iter()
+                .map(|field| {
+                    let field_ident = field.ident.as_ref().expect("named field must have ident");
+                    quote::quote!(self.#field_ident)
+                })
+                .collect();
+
+            let build_fields = fields.named.iter().map(|field| {
+                let field_ident = field.ident.as_ref().expect("named field must have ident");
+                let field_ty = &field.ty;
+                quote::quote!(#field_ident: <#field_ty as ::xdevs::port::Bag>::build())
+            });
+
+            let is_empty_body = if accesses.is_empty() {
+                quote::quote! { true }
+            } else {
+                quote::quote! { #(#accesses.is_empty())&&* }
+            };
+
             let variants: Vec<TokenStream2> = fields
                 .named
                 .iter()
@@ -142,7 +85,7 @@ pub fn derive_asport(input: DeriveInput) -> Result<TokenStream2> {
                         info.ident.as_ref().expect("named field must have ident"),
                     );
                     let ty = &info.ty;
-                    quote::quote! { #variant(<#ty as ::xdevs::port::AsPort>::Value) }
+                    quote::quote! { #variant(<#ty as ::xdevs::port::Bag>::Value) }
                 })
                 .collect();
 
@@ -175,8 +118,25 @@ pub fn derive_asport(input: DeriveInput) -> Result<TokenStream2> {
                 .collect();
 
             Ok(quote::quote! {
-                unsafe impl #impl_generics ::xdevs::port::AsPort for #ident #ty_generics #where_clause {
+                unsafe impl #impl_generics ::xdevs::port::Bag for #ident #ty_generics #where_clause {
                     type Value = #private_mod_ident::PortMux #ty_generics;
+
+                    #[inline]
+                    fn build() -> Self {
+                        Self {
+                            #(#build_fields),*
+                        }
+                    }
+
+                    #[inline]
+                    fn is_empty(&self) -> bool {
+                        #is_empty_body
+                    }
+
+                    #[inline]
+                    fn clear(&mut self) {
+                        #( #accesses.clear(); )*
+                    }
 
                     fn inject_event(&mut self, event: Self::Value) -> ::core::result::Result<(), Self::Value> {
                         match event {

--- a/macros/src/derive.rs
+++ b/macros/src/derive.rs
@@ -97,11 +97,11 @@ pub fn derive_bag(input: DeriveInput) -> Result<TokenStream2> {
     })
 }
 
-pub fn derive_bagmux(input: DeriveInput) -> Result<TokenStream2> {
+pub fn derive_asport(input: DeriveInput) -> Result<TokenStream2> {
     let ident = input.ident;
     let snake_case_ident = Ident::new(&ident.to_string().to_snake_case(), ident.span());
     let private_mod_ident = Ident::new(
-        &format!("_xdevs_no_std_{}_bagmux", snake_case_ident),
+        &format!("_xdevs_no_std_{}_asport", snake_case_ident),
         ident.span(),
     );
     let generics = input.generics;
@@ -111,7 +111,7 @@ pub fn derive_bagmux(input: DeriveInput) -> Result<TokenStream2> {
         _ => {
             return Err(Error::new_spanned(
                 ident,
-                "BagMux can only be derived for structs",
+                "AsPort can only be derived for structs",
             ))
         }
     };
@@ -121,15 +121,15 @@ pub fn derive_bagmux(input: DeriveInput) -> Result<TokenStream2> {
     match fields {
         Fields::Unnamed(_) => Err(Error::new_spanned(
             ident,
-            "BagMux cannot be derived for tuple structs",
+            "AsPort cannot be derived for tuple structs",
         )),
         Fields::Unit => Ok(quote::quote! {
-            unsafe impl #impl_generics ::xdevs::port::BagMux for #ident #ty_generics #where_clause {
-                type Mux = ();
-                fn inject_event(&mut self, _event: Self::Mux) -> ::core::result::Result<(), Self::Mux> {
+            unsafe impl #impl_generics ::xdevs::port::AsPort for #ident #ty_generics #where_clause {
+                type Value = ();
+                fn inject_event(&mut self, _event: Self::Value) -> ::core::result::Result<(), Self::Value> {
                     Ok(())
                 }
-                fn eject_events(&self, _ejector: impl FnMut(Self::Mux)) {}
+                fn eject_events(&self, _ejector: impl FnMut(Self::Value)) {}
             }
         }),
 
@@ -142,7 +142,7 @@ pub fn derive_bagmux(input: DeriveInput) -> Result<TokenStream2> {
                         info.ident.as_ref().expect("named field must have ident"),
                     );
                     let ty = &info.ty;
-                    quote::quote! { #variant(<#ty as ::xdevs::port::BagMux>::Mux) }
+                    quote::quote! { #variant(<#ty as ::xdevs::port::AsPort>::Value) }
                 })
                 .collect();
 
@@ -155,7 +155,7 @@ pub fn derive_bagmux(input: DeriveInput) -> Result<TokenStream2> {
                     );
                     let field = info.ident.as_ref().expect("named field must have ident");
                     quote::quote! {
-                        Self::Mux::#variant(value) => self.#field.inject_event(value).map_err(Self::Mux::#variant)
+                        Self::Value::#variant(value) => self.#field.inject_event(value).map_err(Self::Value::#variant)
                     }
                 })
                 .collect();
@@ -169,22 +169,22 @@ pub fn derive_bagmux(input: DeriveInput) -> Result<TokenStream2> {
                     );
                     let field = info.ident.as_ref().expect("named field must have ident");
                     quote::quote! {
-                        self.#field.eject_events(|v| ejector(Self::Mux::#variant(v)));
+                        self.#field.eject_events(|v| ejector(Self::Value::#variant(v)));
                     }
                 })
                 .collect();
 
             Ok(quote::quote! {
-                unsafe impl #impl_generics ::xdevs::port::BagMux for #ident #ty_generics #where_clause {
-                    type Mux = #private_mod_ident::PortMux #ty_generics;
+                unsafe impl #impl_generics ::xdevs::port::AsPort for #ident #ty_generics #where_clause {
+                    type Value = #private_mod_ident::PortMux #ty_generics;
 
-                    fn inject_event(&mut self, event: Self::Mux) -> ::core::result::Result<(), Self::Mux> {
+                    fn inject_event(&mut self, event: Self::Value) -> ::core::result::Result<(), Self::Value> {
                         match event {
                             #(#match_arms),*
                         }
                     }
 
-                    fn eject_events(&self, mut ejector: impl FnMut(Self::Mux)) {
+                    fn eject_events(&self, mut ejector: impl FnMut(Self::Value)) {
                         #(#propagations)*
                     }
                 }

--- a/macros/src/derive.rs
+++ b/macros/src/derive.rs
@@ -1,9 +1,7 @@
 use heck::ToSnakeCase;
 use heck::ToUpperCamelCase;
 use proc_macro2::TokenStream as TokenStream2;
-use syn::{Data, DeriveInput, Error, Field, Fields, Ident, Index, Result, Type};
-
-use crate::combine_err;
+use syn::{Data, DeriveInput, Error, Fields, Ident, Index, Result};
 
 pub fn derive_bag(input: DeriveInput) -> Result<TokenStream2> {
     let ident = input.ident;
@@ -100,7 +98,6 @@ pub fn derive_bag(input: DeriveInput) -> Result<TokenStream2> {
 }
 
 pub fn derive_bagmux(input: DeriveInput) -> Result<TokenStream2> {
-    // Prepare the struct fields and generics
     let ident = input.ident;
     let snake_case_ident = Ident::new(&ident.to_string().to_snake_case(), ident.span());
     let private_mod_ident = Ident::new(
@@ -114,7 +111,7 @@ pub fn derive_bagmux(input: DeriveInput) -> Result<TokenStream2> {
         _ => {
             return Err(Error::new_spanned(
                 ident,
-                "Bag can only be derived for structs",
+                "BagMux can only be derived for structs",
             ))
         }
     };
@@ -126,24 +123,17 @@ pub fn derive_bagmux(input: DeriveInput) -> Result<TokenStream2> {
             ident,
             "BagMux cannot be derived for tuple structs",
         )),
-        Fields::Unit => {
-            Ok(quote::quote! {
+        Fields::Unit => Ok(quote::quote! {
             unsafe impl #impl_generics ::xdevs::port::BagMux for #ident #ty_generics #where_clause {
                 type Mux = ();
-                fn inject_event(&mut self, _event: Self::Mux) {
-                    // No ports to receive input
+                fn inject_event(&mut self, _event: Self::Mux) -> Result<(), Self::Mux> {
+                    Ok(())
                 }
-                fn eject_events(&self, _ejector: impl FnMut(Self::Mux)) {
-                    // No ports to produce output
-                }
-            }})
-        }
+                fn eject_events(&self, _ejector: impl FnMut(Self::Mux)) {}
+            }
+        }),
 
         Fields::Named(fields) => {
-            // Define the accumulator
-            let mut acc: Option<Error> = None;
-
-            // Input match arms and output propagations
             let variants: Vec<TokenStream2> = fields
                 .named
                 .iter()
@@ -152,7 +142,7 @@ pub fn derive_bagmux(input: DeriveInput) -> Result<TokenStream2> {
                         info.ident.as_ref().expect("named field must have ident"),
                     );
                     let ty = &info.ty;
-                    quote::quote! { #variant(<#ty as ::xdevs::port::AsPort>::Item) }
+                    quote::quote! { #variant(<#ty as ::xdevs::port::BagMux>::Mux) }
                 })
                 .collect();
 
@@ -163,18 +153,9 @@ pub fn derive_bagmux(input: DeriveInput) -> Result<TokenStream2> {
                     let variant = to_pascal_case_ident(
                         info.ident.as_ref().expect("named field must have ident"),
                     );
-
-                    match expand_input_match_arm(info, &variant) {
-                        Ok(arm_body) => quote::quote! {
-                            Self::Mux::#variant(value) => #arm_body
-                        },
-                        Err(err) => {
-                            combine_err(&mut acc, err);
-                            // Emit a dummy arm to satisfy exact behavior and match exhaustiveness
-                            quote::quote! {
-                                Self::Mux::#variant(_) => Ok(())
-                            }
-                        }
+                    let field = info.ident.as_ref().expect("named field must have ident");
+                    quote::quote! {
+                        Self::Mux::#variant(value) => self.#field.inject_event(value).map_err(Self::Mux::#variant)
                     }
                 })
                 .collect();
@@ -186,48 +167,31 @@ pub fn derive_bagmux(input: DeriveInput) -> Result<TokenStream2> {
                     let variant = to_pascal_case_ident(
                         info.ident.as_ref().expect("named field must have ident"),
                     );
-
-                    match expand_output_for(info, &variant) {
-                        Ok(for_body) => quote::quote! {
-                            #for_body
-                        },
-                        Err(err) => {
-                            combine_err(&mut acc, err);
-                            // Output nothing for the failed field, errors handle it later
-                            quote::quote! {}
-                        }
+                    let field = info.ident.as_ref().expect("named field must have ident");
+                    quote::quote! {
+                        self.#field.eject_events(|v| ejector(Self::Mux::#variant(v)));
                     }
                 })
                 .collect();
 
-            if let Some(err) = acc {
-                return Err(err);
-            }
-
-            let inject_event_body = quote::quote! {
-                fn inject_event(&mut self, event: Self::Mux) -> Result<(), Self::Mux> {
-                    match event {
-                        #(#match_arms),*
-                    }
-                }
-            };
-
-            let eject_events_body = quote::quote! {
-                fn eject_events(&self, mut ejector: impl FnMut(Self::Mux)) {
-                    #(#propagations)*
-                }
-            };
-
             Ok(quote::quote! {
                 unsafe impl #impl_generics ::xdevs::port::BagMux for #ident #ty_generics #where_clause {
                     type Mux = #private_mod_ident::PortMux #ty_generics;
-                    #inject_event_body
-                    #eject_events_body
+
+                    fn inject_event(&mut self, event: Self::Mux) -> Result<(), Self::Mux> {
+                        match event {
+                            #(#match_arms),*
+                        }
+                    }
+
+                    fn eject_events(&self, mut ejector: impl FnMut(Self::Mux)) {
+                        #(#propagations)*
+                    }
                 }
 
                 mod #private_mod_ident {
                     use super::*;
-                    /// Auto-generated enum for top-level channel communication.
+
                     #[derive(Clone)]
                     pub enum PortMux #impl_generics #where_clause {
                         #(#variants),*
@@ -238,117 +202,6 @@ pub fn derive_bagmux(input: DeriveInput) -> Result<TokenStream2> {
     }
 }
 
-/// Converts a snake_case identifier to PascalCase.
 fn to_pascal_case_ident(ident: &Ident) -> Ident {
     Ident::new(&ident.to_string().to_upper_camel_case(), ident.span())
-}
-
-/// Generate a match arm for the input enum to add received values to the corresponding input port.
-fn expand_input_match_arm(info: &Field, variant: &Ident) -> Result<TokenStream2> {
-    fn input_match_arm_body(
-        ty: &Type,
-        variant: &Ident,
-        comes_from_array: bool,
-    ) -> Result<TokenStream2> {
-        match ty {
-            Type::Path(_) => {
-                let mut token = quote::quote! {
-                    let result = port.add_value(value);
-                };
-                token.extend(if comes_from_array {
-                    quote::quote! {
-                        if let Err(value) = result {
-                            Err(Self::Mux::#variant((index, value)))
-
-                        } else {
-                            Ok(())
-                        }
-                    }
-                } else {
-                    quote::quote! {
-                        if let Err(value) = result {
-                            Err(Self::Mux::#variant(value))
-                        } else {
-                            Ok(())
-                        }
-                    }
-                });
-                Ok(token)
-            }
-            Type::Array(array) => {
-                let elem_ty = &array.elem;
-                let body = input_match_arm_body(elem_ty, variant, true)?;
-                Ok(quote::quote! {
-                    let (index, value) = value;
-                    if let Some(port) = port.get_mut(index)
-                    {
-                        #body
-                    }
-                    else
-                    {
-                        Ok(()) // Ignore out-of-bounds index, as it cannot be added to any port
-                    }
-                })
-            }
-            _ => Err(Error::new_spanned(
-                ty,
-                "unsupported input port type; expected array or Port",
-            )),
-        }
-    }
-    let field = &info.ident;
-    let ty = &info.ty;
-    let body = input_match_arm_body(ty, variant, false)?;
-    Ok(quote::quote! {
-        {
-            let port = &mut self.#field;
-            {
-                #body
-            }
-        }
-    })
-}
-
-/// Generate a for loop for the output enum to publish values from the corresponding output port.
-fn expand_output_for(info: &Field, variant: &Ident) -> Result<TokenStream2> {
-    fn output_for_body(ty: &Type, variant: &Ident, from_array: bool) -> Result<TokenStream2> {
-        match ty {
-            Type::Path(_) => {
-                if from_array {
-                    Ok(quote::quote! {
-                        for value in port.get_values() {
-                            ejector(Self::Mux::#variant((index, value.clone())));
-                        }
-                    })
-                } else {
-                    Ok(quote::quote! {
-                        for value in port.get_values() {
-                            ejector(Self::Mux::#variant(value.clone()));
-                        }
-                    })
-                }
-            }
-            Type::Array(array) => {
-                let body = output_for_body(&array.elem, variant, true)?;
-                Ok(quote::quote! {
-                    for (index, port) in port.iter().enumerate() {
-                        #body
-                    }
-                })
-            }
-            _ => Err(Error::new_spanned(
-                ty,
-                "unsupported output port type; expected array or Port",
-            )),
-        }
-    }
-    let field = &info.ident;
-    let ty = &info.ty;
-    let body = output_for_body(ty, variant, false)?;
-    Ok(quote::quote! {
-        let port = &self.#field;
-        {
-            #body
-        }
-    })
 }

--- a/macros/src/derive.rs
+++ b/macros/src/derive.rs
@@ -47,7 +47,7 @@ pub fn derive_bag(input: DeriveInput) -> Result<TokenStream2> {
                 fn clear(&mut self) {}
 
                 #[inline]
-                fn inject_event(&mut self, _event: Self::Value) -> ::core::result::Result<(), Self::Value> {
+                fn add_value(&mut self, _event: Self::Value) -> ::core::result::Result<(), Self::Value> {
                     Ok(())
                 }
 
@@ -98,7 +98,7 @@ pub fn derive_bag(input: DeriveInput) -> Result<TokenStream2> {
                     );
                     let field = info.ident.as_ref().expect("named field must have ident");
                     quote::quote! {
-                        Self::Value::#variant(value) => self.#field.inject_event(value).map_err(Self::Value::#variant)
+                        Self::Value::#variant(value) => self.#field.add_value(value).map_err(Self::Value::#variant)
                     }
                 })
                 .collect();
@@ -138,7 +138,7 @@ pub fn derive_bag(input: DeriveInput) -> Result<TokenStream2> {
                         #( #accesses.clear(); )*
                     }
 
-                    fn inject_event(&mut self, event: Self::Value) -> ::core::result::Result<(), Self::Value> {
+                    fn add_value(&mut self, event: Self::Value) -> ::core::result::Result<(), Self::Value> {
                         match event {
                             #(#match_arms),*
                         }

--- a/macros/src/derive.rs
+++ b/macros/src/derive.rs
@@ -126,7 +126,7 @@ pub fn derive_bagmux(input: DeriveInput) -> Result<TokenStream2> {
         Fields::Unit => Ok(quote::quote! {
             unsafe impl #impl_generics ::xdevs::port::BagMux for #ident #ty_generics #where_clause {
                 type Mux = ();
-                fn inject_event(&mut self, _event: Self::Mux) -> Result<(), Self::Mux> {
+                fn inject_event(&mut self, _event: Self::Mux) -> ::core::result::Result<(), Self::Mux> {
                     Ok(())
                 }
                 fn eject_events(&self, _ejector: impl FnMut(Self::Mux)) {}
@@ -178,7 +178,7 @@ pub fn derive_bagmux(input: DeriveInput) -> Result<TokenStream2> {
                 unsafe impl #impl_generics ::xdevs::port::BagMux for #ident #ty_generics #where_clause {
                     type Mux = #private_mod_ident::PortMux #ty_generics;
 
-                    fn inject_event(&mut self, event: Self::Mux) -> Result<(), Self::Mux> {
+                    fn inject_event(&mut self, event: Self::Mux) -> ::core::result::Result<(), Self::Mux> {
                         match event {
                             #(#match_arms),*
                         }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -91,15 +91,6 @@ pub fn derive_bag(input: TokenStream) -> TokenStream {
     }
 }
 
-#[proc_macro_derive(AsPort)]
-pub fn derive_asport(input: TokenStream) -> TokenStream {
-    let input: syn::DeriveInput = syn::parse_macro_input!(input);
-    match derive::derive_asport(input) {
-        Ok(tokens) => tokens.into(),
-        Err(err) => err.to_compile_error().into(),
-    }
-}
-
 // Function to combine errors when parsing
 pub(crate) fn combine_err(acc: &mut Option<Error>, err: Error) {
     match acc {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -91,10 +91,10 @@ pub fn derive_bag(input: TokenStream) -> TokenStream {
     }
 }
 
-#[proc_macro_derive(BagMux)]
-pub fn derive_bagmux(input: TokenStream) -> TokenStream {
+#[proc_macro_derive(AsPort)]
+pub fn derive_asport(input: TokenStream) -> TokenStream {
     let input: syn::DeriveInput = syn::parse_macro_input!(input);
-    match derive::derive_bagmux(input) {
+    match derive::derive_asport(input) {
         Ok(tokens) => tokens.into(),
         Err(err) => err.to_compile_error().into(),
     }

--- a/macros/src/rt_engine.rs
+++ b/macros/src/rt_engine.rs
@@ -210,7 +210,7 @@ pub fn expand(args: RtEngineArgs, item: ItemImpl) -> Result<TokenStream2> {
 
         /// Auto-generated input enum for channel communication alias.
         pub type #input_enum_ident #model_ty_generics = <<#model_ident #model_ty_generics as ::xdevs::Component>::
-        Input as ::xdevs::port::BagMux>::Mux;
+        Input as ::xdevs::port::AsPort>::Value;
         });
 
         let input_channel_tokens = RtEngineBackend::input_channel(&args, &model_ident);
@@ -223,7 +223,7 @@ pub fn expand(args: RtEngineArgs, item: ItemImpl) -> Result<TokenStream2> {
         let map_input_body = quote::quote! {
             let input = <Self::InputChannel as ::xdevs::rt_engine::RtEngineInputChannel>::recv(in_channel).await;
             // TODO: Return Result when embassy time is merged
-            let _ = <Self as ::xdevs::port::BagMux>::inject_event(self, input);
+            let _ = <Self as ::xdevs::port::AsPort>::inject_event(self, input);
         };
 
         inject_input_impl = quote::quote! {
@@ -255,7 +255,7 @@ pub fn expand(args: RtEngineArgs, item: ItemImpl) -> Result<TokenStream2> {
 
             /// Auto-generated output enum for channel communication alias.
             pub type #output_enum_ident #model_ty_generics = <<#model_ident #model_ty_generics as ::xdevs::Component>::
-            Output as ::xdevs::port::BagMux>::Mux;
+            Output as ::xdevs::port::AsPort>::Value;
         });
 
         let output_channel_tokens = RtEngineBackend::output_channel(&args, &model_ident);
@@ -270,7 +270,7 @@ pub fn expand(args: RtEngineArgs, item: ItemImpl) -> Result<TokenStream2> {
                     output,
                 );
             };
-            <Self as ::xdevs::port::BagMux>::eject_events(self, out_func);
+            <Self as ::xdevs::port::AsPort>::eject_events(self, out_func);
         };
 
         eject_output_impl = quote::quote! {

--- a/macros/src/rt_engine.rs
+++ b/macros/src/rt_engine.rs
@@ -223,7 +223,7 @@ pub fn expand(args: RtEngineArgs, item: ItemImpl) -> Result<TokenStream2> {
         let map_input_body = quote::quote! {
             let input = <Self::InputChannel as ::xdevs::rt_engine::RtEngineInputChannel>::recv(in_channel).await;
             // TODO: Return Result when embassy time is merged
-            let _ = <Self as ::xdevs::port::Bag>::inject_event(self, input);
+            let _ = <Self as ::xdevs::port::Bag>::add_value(self, input);
         };
 
         inject_input_impl = quote::quote! {

--- a/macros/src/rt_engine.rs
+++ b/macros/src/rt_engine.rs
@@ -210,7 +210,7 @@ pub fn expand(args: RtEngineArgs, item: ItemImpl) -> Result<TokenStream2> {
 
         /// Auto-generated input enum for channel communication alias.
         pub type #input_enum_ident #model_ty_generics = <<#model_ident #model_ty_generics as ::xdevs::Component>::
-        Input as ::xdevs::port::AsPort>::Value;
+        Input as ::xdevs::port::Bag>::Value;
         });
 
         let input_channel_tokens = RtEngineBackend::input_channel(&args, &model_ident);
@@ -223,7 +223,7 @@ pub fn expand(args: RtEngineArgs, item: ItemImpl) -> Result<TokenStream2> {
         let map_input_body = quote::quote! {
             let input = <Self::InputChannel as ::xdevs::rt_engine::RtEngineInputChannel>::recv(in_channel).await;
             // TODO: Return Result when embassy time is merged
-            let _ = <Self as ::xdevs::port::AsPort>::inject_event(self, input);
+            let _ = <Self as ::xdevs::port::Bag>::inject_event(self, input);
         };
 
         inject_input_impl = quote::quote! {
@@ -255,7 +255,7 @@ pub fn expand(args: RtEngineArgs, item: ItemImpl) -> Result<TokenStream2> {
 
             /// Auto-generated output enum for channel communication alias.
             pub type #output_enum_ident #model_ty_generics = <<#model_ident #model_ty_generics as ::xdevs::Component>::
-            Output as ::xdevs::port::AsPort>::Value;
+            Output as ::xdevs::port::Bag>::Value;
         });
 
         let output_channel_tokens = RtEngineBackend::output_channel(&args, &model_ident);
@@ -270,7 +270,7 @@ pub fn expand(args: RtEngineArgs, item: ItemImpl) -> Result<TokenStream2> {
                     output,
                 );
             };
-            <Self as ::xdevs::port::AsPort>::eject_events(self, out_func);
+            <Self as ::xdevs::port::Bag>::eject_events(self, out_func);
         };
 
         eject_output_impl = quote::quote! {

--- a/macros/src/rt_engine/backend/embassy.rs
+++ b/macros/src/rt_engine/backend/embassy.rs
@@ -25,7 +25,7 @@ impl Backend for RtEngineBackend {
         let in_channel_size = args.in_channel_size;
 
         let channel_type = quote::quote! { ::xdevs::export::InputChannel<'static,
-            <Self as ::xdevs::port::AsPort>::Value,
+            <Self as ::xdevs::port::Bag>::Value,
             #in_channel_size
         > };
         let upper_name = model_ident.to_string().to_shouty_snake_case();
@@ -35,7 +35,7 @@ impl Backend for RtEngineBackend {
         let private_channel = quote::quote! {
             /// Auto-generated static input channel.
             pub static #channel_ident: ::xdevs::export::Channel<
-                <#input_ident as ::xdevs::port::AsPort>::Value,
+                <#input_ident as ::xdevs::port::Bag>::Value,
                 #in_channel_size
             > = ::xdevs::export::Channel::new();
         };
@@ -53,7 +53,7 @@ impl Backend for RtEngineBackend {
         let max_out_subs = args.max_out_subs;
 
         let channel_type = quote::quote! { ::xdevs::export::OutputChannel<'static,
-            <Self as ::xdevs::port::AsPort>::Value,
+            <Self as ::xdevs::port::Bag>::Value,
             #out_channel_size,
             #max_out_subs
         > };
@@ -64,7 +64,7 @@ impl Backend for RtEngineBackend {
         let private_channel = quote::quote! {
             /// Auto-generated static output PubSub channel.
             pub static #channel_ident: ::xdevs::export::PubSubChannel<
-                <#output_ident as ::xdevs::port::AsPort>::Value,
+                <#output_ident as ::xdevs::port::Bag>::Value,
                 #out_channel_size,
                 #max_out_subs,
             > = ::xdevs::export::PubSubChannel::new();

--- a/macros/src/rt_engine/backend/embassy.rs
+++ b/macros/src/rt_engine/backend/embassy.rs
@@ -25,7 +25,7 @@ impl Backend for RtEngineBackend {
         let in_channel_size = args.in_channel_size;
 
         let channel_type = quote::quote! { ::xdevs::export::InputChannel<'static,
-            <Self as ::xdevs::port::BagMux>::Mux,
+            <Self as ::xdevs::port::AsPort>::Value,
             #in_channel_size
         > };
         let upper_name = model_ident.to_string().to_shouty_snake_case();
@@ -35,7 +35,7 @@ impl Backend for RtEngineBackend {
         let private_channel = quote::quote! {
             /// Auto-generated static input channel.
             pub static #channel_ident: ::xdevs::export::Channel<
-                <#input_ident as ::xdevs::port::BagMux>::Mux,
+                <#input_ident as ::xdevs::port::AsPort>::Value,
                 #in_channel_size
             > = ::xdevs::export::Channel::new();
         };
@@ -53,7 +53,7 @@ impl Backend for RtEngineBackend {
         let max_out_subs = args.max_out_subs;
 
         let channel_type = quote::quote! { ::xdevs::export::OutputChannel<'static,
-            <Self as ::xdevs::port::BagMux>::Mux,
+            <Self as ::xdevs::port::AsPort>::Value,
             #out_channel_size,
             #max_out_subs
         > };
@@ -64,7 +64,7 @@ impl Backend for RtEngineBackend {
         let private_channel = quote::quote! {
             /// Auto-generated static output PubSub channel.
             pub static #channel_ident: ::xdevs::export::PubSubChannel<
-                <#output_ident as ::xdevs::port::BagMux>::Mux,
+                <#output_ident as ::xdevs::port::AsPort>::Value,
                 #out_channel_size,
                 #max_out_subs,
             > = ::xdevs::export::PubSubChannel::new();

--- a/macros/src/rt_engine/backend/tokio.rs
+++ b/macros/src/rt_engine/backend/tokio.rs
@@ -30,7 +30,7 @@ impl Backend for RtEngineBackend {
     fn input_channel(args: &RtEngineArgs, _model_ident: &Ident) -> ChannelTokens {
         let in_channel_size = args.in_channel_size;
         let channel_type = quote::quote! { ::xdevs::export::InputChannel<
-            <Self as ::xdevs::port::BagMux>::Mux,
+            <Self as ::xdevs::port::AsPort>::Value,
             #in_channel_size
         > };
         let channel_call = quote::quote! {::xdevs::export::InputChannel::new() };
@@ -45,7 +45,7 @@ impl Backend for RtEngineBackend {
     fn output_channel(args: &RtEngineArgs, _model_ident: &Ident) -> ChannelTokens {
         let out_channel_size = args.out_channel_size;
         let channel_type = quote::quote! { ::xdevs::export::OutputChannel<
-            <Self as ::xdevs::port::BagMux>::Mux,
+            <Self as ::xdevs::port::AsPort>::Value,
             #out_channel_size
         > };
         let channel_call = quote::quote! {::xdevs::export::OutputChannel::new() };

--- a/macros/src/rt_engine/backend/tokio.rs
+++ b/macros/src/rt_engine/backend/tokio.rs
@@ -30,7 +30,7 @@ impl Backend for RtEngineBackend {
     fn input_channel(args: &RtEngineArgs, _model_ident: &Ident) -> ChannelTokens {
         let in_channel_size = args.in_channel_size;
         let channel_type = quote::quote! { ::xdevs::export::InputChannel<
-            <Self as ::xdevs::port::AsPort>::Value,
+            <Self as ::xdevs::port::Bag>::Value,
             #in_channel_size
         > };
         let channel_call = quote::quote! {::xdevs::export::InputChannel::new() };
@@ -45,7 +45,7 @@ impl Backend for RtEngineBackend {
     fn output_channel(args: &RtEngineArgs, _model_ident: &Ident) -> ChannelTokens {
         let out_channel_size = args.out_channel_size;
         let channel_type = quote::quote! { ::xdevs::export::OutputChannel<
-            <Self as ::xdevs::port::AsPort>::Value,
+            <Self as ::xdevs::port::Bag>::Value,
             #out_channel_size
         > };
         let channel_call = quote::quote! {::xdevs::export::OutputChannel::new() };

--- a/src/component/atomic.rs
+++ b/src/component/atomic.rs
@@ -111,7 +111,7 @@ impl<T: Atomic> Atomic for alloc::boxed::Box<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Atomic, AtomicKind, Component, Port};
+    use crate::{Atomic, AtomicKind, Bag, Component, Port};
 
     struct CallTracker {
         start: bool,

--- a/src/devstone/common.rs
+++ b/src/devstone/common.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "std"))]
 use crate::Instant;
 use crate::{
-    Atomic, AtomicKind, Component, ComponentsInput, ComponentsOutput, Coupled, CoupledKind,
+    Atomic, AtomicKind, Bag, Component, ComponentsInput, ComponentsOutput, Coupled, CoupledKind,
     Duration, Port,
 };
 #[cfg(feature = "std")]

--- a/src/gpt.rs
+++ b/src/gpt.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Atomic, AtomicKind, Component, ComponentsInput, ComponentsOutput, Coupled, CoupledKind, Port,
+    Atomic, AtomicKind, Bag, Component, ComponentsInput, ComponentsOutput, Coupled, CoupledKind,
+    Port,
 };
 /// Generator that produces jobs at a fixed period until told to stop.
 pub struct Generator {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub use component::{
     AtomicKind, Component, ComponentsKind, CoupledKind,
 };
 pub use embassy_time::{Duration, Instant};
-pub use port::Port;
+pub use port::{Bag, Port};
 pub use simulation::Config;
 pub use xdevs_no_std_macros::*;
 
@@ -30,5 +30,6 @@ pub use xdevs_no_std_macros::*;
 ///
 /// Intended to be imported with `use xdevs::prelude::*;`.
 pub mod prelude {
+    pub use crate::port::Bag;
     pub use crate::simulation::{AbstractSimulator, Simulable};
 }

--- a/src/port.rs
+++ b/src/port.rs
@@ -41,12 +41,6 @@ impl<T: Clone, const N: usize> Port<T, N> {
         self.0.clear()
     }
 
-    /// Adds a value to the port.
-    #[inline]
-    pub fn add_value(&mut self, item: T) -> Result<(), T> {
-        self.0.push(item)
-    }
-
     /// Adds multiple values to the port.
     #[inline]
     pub fn add_values(&mut self, items: &[T]) -> Result<(), heapless::CapacityError> {
@@ -84,8 +78,8 @@ unsafe impl<T: Clone, const N: usize> Bag for Port<T, N> {
         self.clear()
     }
 
-    fn inject_event(&mut self, event: Self::Value) -> Result<(), Self::Value> {
-        self.add_value(event)
+    fn add_value(&mut self, event: Self::Value) -> Result<(), Self::Value> {
+        self.0.push(event)
     }
 
     fn eject_events(&self, mut ejector: impl FnMut(Self::Value)) {
@@ -99,53 +93,58 @@ unsafe impl<T: Clone, const N: usize> Bag for Port<T, N> {
 ///
 /// # Safety
 ///
-/// This trait must be implemented via the [`Bag`](crate::Bag) macro. Do not implement it manually.
+/// This trait must be implemented via the [`Bag`] macro. Do not implement it manually.
 pub unsafe trait Bag {
-    /// The type that represents the ports of the model. Each variant corresponds to a port.
+    /// The type that represents the event bags of the model.
     type Value;
 
     /// Build a new instance of the bag.
     fn build() -> Self;
 
-    /// Returns `true` if the ports are empty.
+    /// Returns `true` if the event bags are empty.
     fn is_empty(&self) -> bool;
 
-    /// Clears the ports, removing all values.
+    /// Clears the event bags, removing all values.
     fn clear(&mut self);
 
-    /// Maps the type to the corresponding port, allowing to inject events to the bag.
-    fn inject_event(&mut self, event: Self::Value) -> Result<(), Self::Value>;
+    /// Injects a value into the bag.
+    fn add_value(&mut self, event: Self::Value) -> Result<(), Self::Value>;
 
-    /// Maps the type to the corresponding port, allowing to receive events from the bag.
+    /// Ejects all events from the bag. Mainly used internally by the [`RtEngine`](crate::rt_engine::RtEngine) to collect all events from the model.
     fn eject_events(&self, ejector: impl FnMut(Self::Value));
 }
 
 unsafe impl<T: Bag, const N: usize> Bag for [T; N] {
     type Value = (usize, T::Value); // Include index to identify which bag the value came from
 
+    #[inline]
     fn build() -> Self {
         core::array::from_fn(|_| T::build())
     }
 
+    #[inline]
     fn is_empty(&self) -> bool {
         self.iter().all(|bag| bag.is_empty())
     }
 
+    #[inline]
     fn clear(&mut self) {
         self.iter_mut().for_each(|bag| bag.clear());
     }
 
-    fn inject_event(&mut self, (index, event): Self::Value) -> Result<(), Self::Value> {
+    #[inline]
+    fn add_value(&mut self, (index, event): Self::Value) -> Result<(), Self::Value> {
         match self.get_mut(index) {
-            Some(elem) => elem.inject_event(event).map_err(|err| (index, err)),
+            Some(elem) => elem.add_value(event).map_err(|err| (index, err)),
             None => Err((index, event)),
         }
     }
 
+    #[inline]
     fn eject_events(&self, mut ejector: impl FnMut(Self::Value)) {
-        for (index, elem) in self.iter().enumerate() {
+        self.iter().enumerate().for_each(|(index, elem)| {
             elem.eject_events(|v| ejector((index, v)));
-        }
+        });
     }
 }
 
@@ -160,7 +159,7 @@ unsafe impl Bag for () {
 
     fn clear(&mut self) {}
 
-    fn inject_event(&mut self, _event: Self::Value) -> Result<(), Self::Value> {
+    fn add_value(&mut self, _event: Self::Value) -> Result<(), Self::Value> {
         Ok(())
     }
 
@@ -186,12 +185,12 @@ macro_rules! impl_bag_for_tuple {
                 $(self.$idx.clear();)+
             }
 
-            fn inject_event(&mut self, event: Self::Value) -> Result<(), Self::Value> {
+            fn add_value(&mut self, event: Self::Value) -> Result<(), Self::Value> {
                 let mut event = event;
                 let mut had_error = false;
                 $(
                     if let Some(v) = event.$idx.take() {
-                        if let Err(e) = self.$idx.inject_event(v) {
+                        if let Err(e) = self.$idx.add_value(v) {
                             event.$idx = Some(e);
                             had_error = true;
                         }
@@ -374,9 +373,9 @@ mod tests {
         let mut bag = <Port<u32, 2> as Bag>::build();
         assert!(bag.is_empty());
 
-        assert!(bag.inject_event(7).is_ok());
-        assert!(bag.inject_event(99).is_ok());
-        assert_eq!(bag.inject_event(42), Err(42));
+        assert!(bag.add_value(7).is_ok());
+        assert!(bag.add_value(99).is_ok());
+        assert_eq!(bag.add_value(42), Err(42));
 
         let mut collected: heapless::Vec<u32, 4> = heapless::Vec::new();
         bag.eject_events(|v| {
@@ -390,13 +389,13 @@ mod tests {
         let mut bags = <[Port<u32, 2>; 3] as Bag>::build();
         assert!(bags.is_empty());
 
-        assert!(bags.inject_event((0, 10)).is_ok());
-        assert!(bags.inject_event((2, 30)).is_ok());
+        assert!(bags.add_value((0, 10)).is_ok());
+        assert!(bags.add_value((2, 30)).is_ok());
 
-        assert_eq!(bags.inject_event((5, 77)), Err((5, 77)));
+        assert_eq!(bags.add_value((5, 77)), Err((5, 77)));
 
-        assert!(bags.inject_event((0, 11)).is_ok());
-        assert_eq!(bags.inject_event((0, 12)), Err((0, 12)));
+        assert!(bags.add_value((0, 11)).is_ok());
+        assert_eq!(bags.add_value((0, 12)), Err((0, 12)));
 
         let mut collected: heapless::Vec<(usize, u32), 4> = heapless::Vec::new();
         bags.eject_events(|(i, v)| {
@@ -410,9 +409,9 @@ mod tests {
         let mut bag = <(Port<u32, 1>, Port<bool, 1>) as Bag>::build();
         assert!(bag.is_empty());
 
-        assert!(bag.inject_event((Some(7u32), None)).is_ok());
-        assert!(bag.inject_event((None, Some(true))).is_ok());
-        assert_eq!(bag.inject_event((Some(99u32), None)), Err((Some(99), None)));
+        assert!(bag.add_value((Some(7u32), None)).is_ok());
+        assert!(bag.add_value((None, Some(true))).is_ok());
+        assert_eq!(bag.add_value((Some(99u32), None)), Err((Some(99), None)));
 
         let mut got_u32: heapless::Vec<u32, 4> = heapless::Vec::new();
         let mut got_bool: heapless::Vec<bool, 4> = heapless::Vec::new();
@@ -432,16 +431,13 @@ mod tests {
     #[test]
     fn tuple_bag_inject_eject_full_preserves_failed_positions() {
         let mut bag = <(Port<u32, 1>, Port<bool, 1>) as Bag>::build();
-        bag.inject_event((Some(1u32), None)).unwrap();
-        bag.inject_event((None, Some(true))).unwrap();
+        bag.add_value((Some(1u32), None)).unwrap();
+        bag.add_value((None, Some(true))).unwrap();
 
-        assert_eq!(bag.inject_event((Some(7u32), None)), Err((Some(7), None)));
+        assert_eq!(bag.add_value((Some(7u32), None)), Err((Some(7), None)));
+        assert_eq!(bag.add_value((None, Some(false))), Err((None, Some(false))));
         assert_eq!(
-            bag.inject_event((None, Some(false))),
-            Err((None, Some(false)))
-        );
-        assert_eq!(
-            bag.inject_event((Some(7u32), Some(false))),
+            bag.add_value((Some(7u32), Some(false))),
             Err((Some(7), Some(false)))
         );
 
@@ -527,11 +523,11 @@ mod tests {
 
         let inner_event = _xdevs_no_std_inner_bag_bag::PortMux::A(42u32);
         let outer_inner = _xdevs_no_std_outer_bag_bag::PortMux::Inner(inner_event);
-        assert!(outer.inject_event(outer_inner).is_ok());
+        assert!(outer.add_value(outer_inner).is_ok());
         assert!(!outer.is_empty());
 
         assert!(outer
-            .inject_event(_xdevs_no_std_outer_bag_bag::PortMux::B(true))
+            .add_value(_xdevs_no_std_outer_bag_bag::PortMux::B(true))
             .is_ok());
 
         let mut got_a: heapless::Vec<u32, 4> = heapless::Vec::new();

--- a/src/port.rs
+++ b/src/port.rs
@@ -1,5 +1,3 @@
-use sealed::Sealed;
-
 /// Port is a generic structure that can be used to store values of any type `T`.
 /// It is the main artifact to exchange data between components.
 /// Note that, in `no_std` environments, the capacity of the port `N` must be known at compile time.
@@ -99,12 +97,6 @@ unsafe impl<T: Clone, const N: usize> BagMux for Port<T, N> {
     }
 }
 
-impl<T: Clone, const N: usize> AsPort for Port<T, N> {
-    type Item = T;
-}
-
-impl<T: Clone, const N: usize> Sealed for Port<T, N> {}
-
 /// Trait that defines the methods that a DEVS event bag set must implement.
 ///
 /// # Safety
@@ -119,16 +111,6 @@ pub unsafe trait Bag {
 
     /// Clears the ports, removing all values.
     fn clear(&mut self);
-}
-
-/// Trait that defines the type inside of a Bag for rt_engine enums.
-///
-/// # Note
-///
-/// This trait is sealed and cannot be implemented by the user
-pub trait AsPort: Bag + Sealed {
-    /// The type of the values contained in the bag.
-    type Item;
 }
 
 /// Trait that defines a type that maps to event bag ports.
@@ -162,10 +144,22 @@ unsafe impl<T: Bag, const N: usize> Bag for [T; N] {
     }
 }
 
-impl<T: AsPort, const N: usize> AsPort for [T; N] {
-    type Item = (usize, T::Item); // Include index to identify which bag the value came from
+unsafe impl<T: BagMux, const N: usize> BagMux for [T; N] {
+    type Mux = (usize, T::Mux); // Include index to identify which bag the value came from
+
+    fn inject_event(&mut self, (index, event): Self::Mux) -> Result<(), Self::Mux> {
+        match self.get_mut(index) {
+            Some(elem) => elem.inject_event(event).map_err(|err| (index, err)),
+            None => Err((index, event)),
+        }
+    }
+
+    fn eject_events(&self, mut ejector: impl FnMut(Self::Mux)) {
+        for (index, elem) in self.iter().enumerate() {
+            elem.eject_events(|v| ejector((index, v)));
+        }
+    }
 }
-impl<T: AsPort, const N: usize> Sealed for [T; N] {}
 
 unsafe impl Bag for () {
     fn build() -> Self {}
@@ -209,11 +203,6 @@ impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T
 impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9);
 impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10);
 impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10, 11 => T11);
-
-mod sealed {
-    /// Trait used to prevent users from implementing certain traits manually.
-    pub trait Sealed {}
-}
 
 #[cfg(test)]
 mod tests {
@@ -359,6 +348,42 @@ mod tests {
     }
 
     #[test]
+    fn port_bagmux_impl_contract() {
+        let mut bag = <Port<u32, 2> as Bag>::build();
+        assert!(bag.is_empty());
+
+        assert!(bag.inject_event(7).is_ok());
+        assert!(bag.inject_event(99).is_ok());
+        assert_eq!(bag.inject_event(42), Err(42));
+
+        let mut collected: heapless::Vec<u32, 4> = heapless::Vec::new();
+        bag.eject_events(|v| {
+            let _ = collected.push(v);
+        });
+        assert_eq!(collected.as_slice(), &[7, 99]);
+    }
+
+    #[test]
+    fn array_bagmux_impl_contract() {
+        let mut bags = <[Port<u32, 2>; 3] as Bag>::build();
+        assert!(bags.is_empty());
+
+        assert!(bags.inject_event((0, 10)).is_ok());
+        assert!(bags.inject_event((2, 30)).is_ok());
+
+        assert_eq!(bags.inject_event((5, 77)), Err((5, 77)));
+
+        assert!(bags.inject_event((0, 11)).is_ok());
+        assert_eq!(bags.inject_event((0, 12)), Err((0, 12)));
+
+        let mut collected: heapless::Vec<(usize, u32), 4> = heapless::Vec::new();
+        bags.eject_events(|(i, v)| {
+            let _ = collected.push((i, v));
+        });
+        assert_eq!(collected.as_slice(), &[(0, 10), (0, 11), (2, 30)]);
+    }
+
+    #[test]
     fn unit_bag_impl() {
         <() as Bag>::build();
         assert!(<() as Bag>::is_empty(&()));
@@ -405,5 +430,47 @@ mod tests {
         let port: Port<u32, 5> = Default::default();
         assert!(port.is_empty());
         assert_eq!(port.len(), 0);
+    }
+
+    #[derive(crate::Bag, crate::BagMux)]
+    struct InnerBag {
+        a: Port<u32, 2>,
+    }
+
+    #[derive(crate::Bag, crate::BagMux)]
+    struct OuterBag {
+        inner: InnerBag,
+        b: Port<bool, 1>,
+    }
+
+    #[test]
+    fn nested_bagmux_impl() {
+        let mut outer = <OuterBag as Bag>::build();
+        assert!(outer.is_empty());
+
+        let inner_event = _xdevs_no_std_inner_bag_bagmux::PortMux::A(42u32);
+        let outer_inner = _xdevs_no_std_outer_bag_bagmux::PortMux::Inner(inner_event);
+        assert!(outer.inject_event(outer_inner).is_ok());
+        assert!(!outer.is_empty());
+
+        assert!(outer
+            .inject_event(_xdevs_no_std_outer_bag_bagmux::PortMux::B(true))
+            .is_ok());
+
+        let mut got_a: heapless::Vec<u32, 4> = heapless::Vec::new();
+        let mut got_b: heapless::Vec<bool, 4> = heapless::Vec::new();
+        outer.eject_events(|ev| match ev {
+            _xdevs_no_std_outer_bag_bagmux::PortMux::Inner(inner) => match inner {
+                _xdevs_no_std_inner_bag_bagmux::PortMux::A(v) => {
+                    let _ = got_a.push(v);
+                }
+            },
+            _xdevs_no_std_outer_bag_bagmux::PortMux::B(v) => {
+                let _ = got_b.push(v);
+            }
+        });
+
+        assert_eq!(got_a.as_slice(), &[42]);
+        assert_eq!(got_b.as_slice(), &[true]);
     }
 }

--- a/src/port.rs
+++ b/src/port.rs
@@ -70,6 +70,8 @@ impl<T: Clone, const N: usize> Port<T, N> {
 }
 
 unsafe impl<T: Clone, const N: usize> Bag for Port<T, N> {
+    type Value = T;
+
     fn build() -> Self {
         Self::new()
     }
@@ -81,10 +83,6 @@ unsafe impl<T: Clone, const N: usize> Bag for Port<T, N> {
     fn clear(&mut self) {
         self.clear()
     }
-}
-
-unsafe impl<T: Clone, const N: usize> AsPort for Port<T, N> {
-    type Value = T;
 
     fn inject_event(&mut self, event: Self::Value) -> Result<(), Self::Value> {
         self.add_value(event)
@@ -103,6 +101,9 @@ unsafe impl<T: Clone, const N: usize> AsPort for Port<T, N> {
 ///
 /// This trait must be implemented via the [`Bag`](crate::Bag) macro. Do not implement it manually.
 pub unsafe trait Bag {
+    /// The type that represents the ports of the model. Each variant corresponds to a port.
+    type Value;
+
     /// Build a new instance of the bag.
     fn build() -> Self;
 
@@ -111,17 +112,6 @@ pub unsafe trait Bag {
 
     /// Clears the ports, removing all values.
     fn clear(&mut self);
-}
-
-/// Trait that defines a type that maps to event bag ports.
-/// Its main purpose is its usage by the `RtEngine` to inject and eject events from the model's ports.
-///
-/// # Safety
-///
-/// This trait must be implemented via the [`Bag`](crate::Bag) macro. Do not implement it manually.
-pub unsafe trait AsPort: Bag {
-    /// The type that represents the ports of the model. Each variant corresponds to a port.
-    type Value;
 
     /// Maps the type to the corresponding port, allowing to inject events to the bag.
     fn inject_event(&mut self, event: Self::Value) -> Result<(), Self::Value>;
@@ -131,6 +121,8 @@ pub unsafe trait AsPort: Bag {
 }
 
 unsafe impl<T: Bag, const N: usize> Bag for [T; N] {
+    type Value = (usize, T::Value); // Include index to identify which bag the value came from
+
     fn build() -> Self {
         core::array::from_fn(|_| T::build())
     }
@@ -142,10 +134,6 @@ unsafe impl<T: Bag, const N: usize> Bag for [T; N] {
     fn clear(&mut self) {
         self.iter_mut().for_each(|bag| bag.clear());
     }
-}
-
-unsafe impl<T: AsPort, const N: usize> AsPort for [T; N] {
-    type Value = (usize, T::Value); // Include index to identify which bag the value came from
 
     fn inject_event(&mut self, (index, event): Self::Value) -> Result<(), Self::Value> {
         match self.get_mut(index) {
@@ -162,6 +150,8 @@ unsafe impl<T: AsPort, const N: usize> AsPort for [T; N] {
 }
 
 unsafe impl Bag for () {
+    type Value = ();
+
     fn build() -> Self {}
 
     fn is_empty(&self) -> bool {
@@ -169,11 +159,19 @@ unsafe impl Bag for () {
     }
 
     fn clear(&mut self) {}
+
+    fn inject_event(&mut self, _event: Self::Value) -> Result<(), Self::Value> {
+        Ok(())
+    }
+
+    fn eject_events(&self, _ejector: impl FnMut(Self::Value)) {}
 }
 
 macro_rules! impl_bag_for_tuple {
     ($($idx:tt => $T:ident),+) => {
         unsafe impl<$($T: Bag),+> Bag for ($($T,)+) {
+            type Value = ($(Option<$T::Value>,)+);
+
             fn build() -> Self {
                 ($($T::build(),)+)
             }
@@ -187,27 +185,6 @@ macro_rules! impl_bag_for_tuple {
             fn clear(&mut self) {
                 $(self.$idx.clear();)+
             }
-        }
-    }
-}
-
-impl_bag_for_tuple!(0 => T0);
-impl_bag_for_tuple!(0 => T0, 1 => T1);
-impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2);
-impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3);
-impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4);
-impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5);
-impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6);
-impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7);
-impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8);
-impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9);
-impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10);
-impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10, 11 => T11);
-
-macro_rules! impl_asport_for_tuple {
-    ($($idx:tt => $T:ident),+) => {
-        unsafe impl<$($T: AsPort),+> AsPort for ($($T,)+) {
-            type Value = ($(Option<$T::Value>,)+);
 
             fn inject_event(&mut self, event: Self::Value) -> Result<(), Self::Value> {
                 let mut event = event;
@@ -236,18 +213,18 @@ macro_rules! impl_asport_for_tuple {
     }
 }
 
-impl_asport_for_tuple!(0 => T0);
-impl_asport_for_tuple!(0 => T0, 1 => T1);
-impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2);
-impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3);
-impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4);
-impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5);
-impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6);
-impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7);
-impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8);
-impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9);
-impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10);
-impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10, 11 => T11);
+impl_bag_for_tuple!(0 => T0);
+impl_bag_for_tuple!(0 => T0, 1 => T1);
+impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2);
+impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3);
+impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4);
+impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5);
+impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6);
+impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7);
+impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8);
+impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9);
+impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10);
+impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10, 11 => T11);
 
 #[cfg(test)]
 mod tests {
@@ -393,7 +370,7 @@ mod tests {
     }
 
     #[test]
-    fn port_asport_impl_contract() {
+    fn port_bag_inject_eject_contract() {
         let mut bag = <Port<u32, 2> as Bag>::build();
         assert!(bag.is_empty());
 
@@ -409,7 +386,7 @@ mod tests {
     }
 
     #[test]
-    fn array_asport_impl_contract() {
+    fn array_bag_inject_eject_contract() {
         let mut bags = <[Port<u32, 2>; 3] as Bag>::build();
         assert!(bags.is_empty());
 
@@ -429,7 +406,7 @@ mod tests {
     }
 
     #[test]
-    fn tuple_asport_impl_2_elements() {
+    fn tuple_bag_inject_eject_2_elements() {
         let mut bag = <(Port<u32, 1>, Port<bool, 1>) as Bag>::build();
         assert!(bag.is_empty());
 
@@ -453,7 +430,7 @@ mod tests {
     }
 
     #[test]
-    fn tuple_asport_impl_full_preserves_failed_positions() {
+    fn tuple_bag_inject_eject_full_preserves_failed_positions() {
         let mut bag = <(Port<u32, 1>, Port<bool, 1>) as Bag>::build();
         bag.inject_event((Some(1u32), None)).unwrap();
         bag.inject_event((None, Some(true))).unwrap();
@@ -532,40 +509,40 @@ mod tests {
         assert_eq!(port.len(), 0);
     }
 
-    #[derive(crate::Bag, crate::AsPort)]
+    #[derive(crate::Bag)]
     struct InnerBag {
         a: Port<u32, 2>,
     }
 
-    #[derive(crate::Bag, crate::AsPort)]
+    #[derive(crate::Bag)]
     struct OuterBag {
         inner: InnerBag,
         b: Port<bool, 1>,
     }
 
     #[test]
-    fn nested_asport_impl() {
+    fn nested_bag_impl() {
         let mut outer = <OuterBag as Bag>::build();
         assert!(outer.is_empty());
 
-        let inner_event = _xdevs_no_std_inner_bag_asport::PortMux::A(42u32);
-        let outer_inner = _xdevs_no_std_outer_bag_asport::PortMux::Inner(inner_event);
+        let inner_event = _xdevs_no_std_inner_bag_bag::PortMux::A(42u32);
+        let outer_inner = _xdevs_no_std_outer_bag_bag::PortMux::Inner(inner_event);
         assert!(outer.inject_event(outer_inner).is_ok());
         assert!(!outer.is_empty());
 
         assert!(outer
-            .inject_event(_xdevs_no_std_outer_bag_asport::PortMux::B(true))
+            .inject_event(_xdevs_no_std_outer_bag_bag::PortMux::B(true))
             .is_ok());
 
         let mut got_a: heapless::Vec<u32, 4> = heapless::Vec::new();
         let mut got_b: heapless::Vec<bool, 4> = heapless::Vec::new();
         outer.eject_events(|ev| match ev {
-            _xdevs_no_std_outer_bag_asport::PortMux::Inner(inner) => match inner {
-                _xdevs_no_std_inner_bag_asport::PortMux::A(v) => {
+            _xdevs_no_std_outer_bag_bag::PortMux::Inner(inner) => match inner {
+                _xdevs_no_std_inner_bag_bag::PortMux::A(v) => {
                     let _ = got_a.push(v);
                 }
             },
-            _xdevs_no_std_outer_bag_asport::PortMux::B(v) => {
+            _xdevs_no_std_outer_bag_bag::PortMux::B(v) => {
                 let _ = got_b.push(v);
             }
         });

--- a/src/port.rs
+++ b/src/port.rs
@@ -85,6 +85,20 @@ unsafe impl<T: Clone, const N: usize> Bag for Port<T, N> {
     }
 }
 
+unsafe impl<T: Clone, const N: usize> BagMux for Port<T, N> {
+    type Mux = T;
+
+    fn inject_event(&mut self, event: Self::Mux) -> Result<(), Self::Mux> {
+        self.add_value(event)
+    }
+
+    fn eject_events(&self, mut ejector: impl FnMut(Self::Mux)) {
+        for value in self.get_values() {
+            ejector(value.clone());
+        }
+    }
+}
+
 impl<T: Clone, const N: usize> AsPort for Port<T, N> {
     type Item = T;
 }

--- a/src/port.rs
+++ b/src/port.rs
@@ -204,6 +204,51 @@ impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T
 impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10);
 impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10, 11 => T11);
 
+macro_rules! impl_bagmux_for_tuple {
+    ($($idx:tt => $T:ident),+) => {
+        unsafe impl<$($T: BagMux),+> BagMux for ($($T,)+) {
+            type Mux = ($(Option<$T::Mux>,)+);
+
+            fn inject_event(&mut self, event: Self::Mux) -> Result<(), Self::Mux> {
+                let mut event = event;
+                let mut had_error = false;
+                $(
+                    if let Some(v) = event.$idx.take() {
+                        if let Err(e) = self.$idx.inject_event(v) {
+                            event.$idx = Some(e);
+                            had_error = true;
+                        }
+                    }
+                )+
+                if had_error { Err(event) } else { Ok(()) }
+            }
+
+            fn eject_events(&self, mut ejector: impl FnMut(Self::Mux)) {
+                $(
+                    self.$idx.eject_events(|v| {
+                        let mut mux: Self::Mux = Default::default();
+                        mux.$idx = Some(v);
+                        ejector(mux);
+                    });
+                )+
+            }
+        }
+    }
+}
+
+impl_bagmux_for_tuple!(0 => T0);
+impl_bagmux_for_tuple!(0 => T0, 1 => T1);
+impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2);
+impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3);
+impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4);
+impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5);
+impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6);
+impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7);
+impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8);
+impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9);
+impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10);
+impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10, 11 => T11);
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -381,6 +426,61 @@ mod tests {
             let _ = collected.push((i, v));
         });
         assert_eq!(collected.as_slice(), &[(0, 10), (0, 11), (2, 30)]);
+    }
+
+    #[test]
+    fn tuple_bagmux_impl_2_elements() {
+        let mut bag = <(Port<u32, 1>, Port<bool, 1>) as Bag>::build();
+        assert!(bag.is_empty());
+
+        assert!(bag.inject_event((Some(7u32), None)).is_ok());
+        assert!(bag.inject_event((None, Some(true))).is_ok());
+        assert_eq!(bag.inject_event((Some(99u32), None)), Err((Some(99), None)));
+
+        let mut got_u32: heapless::Vec<u32, 4> = heapless::Vec::new();
+        let mut got_bool: heapless::Vec<bool, 4> = heapless::Vec::new();
+        bag.eject_events(|ev| match ev {
+            (Some(v), None) => {
+                let _ = got_u32.push(v);
+            }
+            (None, Some(v)) => {
+                let _ = got_bool.push(v);
+            }
+            _ => {}
+        });
+        assert_eq!(got_u32.as_slice(), &[7]);
+        assert_eq!(got_bool.as_slice(), &[true]);
+    }
+
+    #[test]
+    fn tuple_bagmux_impl_full_preserves_failed_positions() {
+        let mut bag = <(Port<u32, 1>, Port<bool, 1>) as Bag>::build();
+        bag.inject_event((Some(1u32), None)).unwrap();
+        bag.inject_event((None, Some(true))).unwrap();
+
+        assert_eq!(bag.inject_event((Some(7u32), None)), Err((Some(7), None)));
+        assert_eq!(
+            bag.inject_event((None, Some(false))),
+            Err((None, Some(false)))
+        );
+        assert_eq!(
+            bag.inject_event((Some(7u32), Some(false))),
+            Err((Some(7), Some(false)))
+        );
+
+        let mut got_u32: heapless::Vec<u32, 4> = heapless::Vec::new();
+        let mut got_bool: heapless::Vec<bool, 4> = heapless::Vec::new();
+        bag.eject_events(|ev| match ev {
+            (Some(v), None) => {
+                let _ = got_u32.push(v);
+            }
+            (None, Some(v)) => {
+                let _ = got_bool.push(v);
+            }
+            _ => {}
+        });
+        assert_eq!(got_u32.as_slice(), &[1]);
+        assert_eq!(got_bool.as_slice(), &[true]);
     }
 
     #[test]

--- a/src/port.rs
+++ b/src/port.rs
@@ -66,22 +66,27 @@ impl<T: Clone, const N: usize> Port<T, N> {
 unsafe impl<T: Clone, const N: usize> Bag for Port<T, N> {
     type Value = T;
 
+    #[inline]
     fn build() -> Self {
         Self::new()
     }
 
+    #[inline]
     fn is_empty(&self) -> bool {
         self.is_empty()
     }
 
+    #[inline]
     fn clear(&mut self) {
         self.clear()
     }
 
+    #[inline]
     fn add_value(&mut self, event: Self::Value) -> Result<(), Self::Value> {
         self.0.push(event)
     }
 
+    #[inline]
     fn eject_events(&self, mut ejector: impl FnMut(Self::Value)) {
         for value in self.get_values() {
             ejector(value.clone());
@@ -95,22 +100,24 @@ unsafe impl<T: Clone, const N: usize> Bag for Port<T, N> {
 ///
 /// This trait must be implemented via the [`Bag`] macro. Do not implement it manually.
 pub unsafe trait Bag {
-    /// The type that represents the event bags of the model.
+    /// The data type of the events stored in the event bag.
     type Value;
 
     /// Build a new instance of the bag.
     fn build() -> Self;
 
-    /// Returns `true` if the event bags are empty.
+    /// Returns `true` if the event bag is empty.
     fn is_empty(&self) -> bool;
 
-    /// Clears the event bags, removing all values.
+    /// Clears the event bag, removing all values.
     fn clear(&mut self);
 
-    /// Injects a value into the bag.
+    /// Adds a new value into the bag.
     fn add_value(&mut self, event: Self::Value) -> Result<(), Self::Value>;
 
-    /// Ejects all events from the bag. Mainly used internally by the [`RtEngine`](crate::rt_engine::RtEngine) to collect all events from the model.
+    /// Ejects all events from the bag.
+    ///
+    /// This function is mainly used internally by the [`RtEngine`](crate::rt_engine::RtEngine) to collect all events from the model.
     fn eject_events(&self, ejector: impl FnMut(Self::Value));
 }
 
@@ -151,19 +158,61 @@ unsafe impl<T: Bag, const N: usize> Bag for [T; N] {
 unsafe impl Bag for () {
     type Value = ();
 
+    #[inline]
     fn build() -> Self {}
 
+    #[inline]
     fn is_empty(&self) -> bool {
         true
     }
 
+    #[inline]
     fn clear(&mut self) {}
 
+    #[inline]
     fn add_value(&mut self, _event: Self::Value) -> Result<(), Self::Value> {
         Ok(())
     }
 
+    #[inline]
     fn eject_events(&self, _ejector: impl FnMut(Self::Value)) {}
+}
+
+unsafe impl<T: Clone> Bag for Option<T> {
+    type Value = T;
+
+    #[inline]
+    fn build() -> Self {
+        None
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.is_none()
+    }
+
+    #[inline]
+    fn clear(&mut self) {
+        *self = None;
+    }
+
+    #[inline]
+    fn add_value(&mut self, event: Self::Value) -> Result<(), Self::Value> {
+        match self {
+            Some(_) => Err(event),
+            None => {
+                *self = Some(event);
+                Ok(())
+            }
+        }
+    }
+
+    #[inline]
+    fn eject_events(&self, mut ejector: impl FnMut(Self::Value)) {
+        if let Some(value) = self {
+            ejector(value.clone());
+        }
+    }
 }
 
 macro_rules! impl_bag_for_tuple {
@@ -171,20 +220,24 @@ macro_rules! impl_bag_for_tuple {
         unsafe impl<$($T: Bag),+> Bag for ($($T,)+) {
             type Value = ($(Option<$T::Value>,)+);
 
+            #[inline]
             fn build() -> Self {
                 ($($T::build(),)+)
             }
 
+            #[inline]
             fn is_empty(&self) -> bool {
                 let mut empty = true;
                 $(empty = empty && self.$idx.is_empty();)+
                 empty
             }
 
+            #[inline]
             fn clear(&mut self) {
                 $(self.$idx.clear();)+
             }
 
+            #[inline]
             fn add_value(&mut self, event: Self::Value) -> Result<(), Self::Value> {
                 let mut event = event;
                 let mut had_error = false;
@@ -199,6 +252,7 @@ macro_rules! impl_bag_for_tuple {
                 if had_error { Err(event) } else { Ok(()) }
             }
 
+            #[inline]
             fn eject_events(&self, mut ejector: impl FnMut(Self::Value)) {
                 $(
                     self.$idx.eject_events(|v| {
@@ -402,6 +456,42 @@ mod tests {
             let _ = collected.push((i, v));
         });
         assert_eq!(collected.as_slice(), &[(0, 10), (0, 11), (2, 30)]);
+    }
+
+    #[test]
+    fn option_bag_impl_contract() {
+        let mut bag = <Option<u32> as Bag>::build();
+        assert!(bag.is_empty());
+
+        assert!(bag.add_value(7).is_ok());
+        assert!(!bag.is_empty());
+
+        bag.clear();
+        assert!(bag.is_empty());
+    }
+
+    #[test]
+    fn option_bag_inject_eject_contract() {
+        let mut bag = <Option<u32> as Bag>::build();
+        assert!(bag.is_empty());
+
+        assert!(bag.add_value(7).is_ok());
+        assert_eq!(bag.add_value(99), Err(99));
+
+        let mut collected: heapless::Vec<u32, 4> = heapless::Vec::new();
+        bag.eject_events(|v| {
+            let _ = collected.push(v);
+        });
+        assert_eq!(collected.as_slice(), &[7]);
+
+        bag.clear();
+        assert!(bag.is_empty());
+
+        let mut collected_after: heapless::Vec<u32, 4> = heapless::Vec::new();
+        bag.eject_events(|v| {
+            let _ = collected_after.push(v);
+        });
+        assert!(collected_after.is_empty());
     }
 
     #[test]

--- a/src/port.rs
+++ b/src/port.rs
@@ -83,14 +83,14 @@ unsafe impl<T: Clone, const N: usize> Bag for Port<T, N> {
     }
 }
 
-unsafe impl<T: Clone, const N: usize> BagMux for Port<T, N> {
-    type Mux = T;
+unsafe impl<T: Clone, const N: usize> AsPort for Port<T, N> {
+    type Value = T;
 
-    fn inject_event(&mut self, event: Self::Mux) -> Result<(), Self::Mux> {
+    fn inject_event(&mut self, event: Self::Value) -> Result<(), Self::Value> {
         self.add_value(event)
     }
 
-    fn eject_events(&self, mut ejector: impl FnMut(Self::Mux)) {
+    fn eject_events(&self, mut ejector: impl FnMut(Self::Value)) {
         for value in self.get_values() {
             ejector(value.clone());
         }
@@ -119,15 +119,15 @@ pub unsafe trait Bag {
 /// # Safety
 ///
 /// This trait must be implemented via the [`Bag`](crate::Bag) macro. Do not implement it manually.
-pub unsafe trait BagMux: Bag {
+pub unsafe trait AsPort: Bag {
     /// The type that represents the ports of the model. Each variant corresponds to a port.
-    type Mux;
+    type Value;
 
     /// Maps the type to the corresponding port, allowing to inject events to the bag.
-    fn inject_event(&mut self, event: Self::Mux) -> Result<(), Self::Mux>;
+    fn inject_event(&mut self, event: Self::Value) -> Result<(), Self::Value>;
 
     /// Maps the type to the corresponding port, allowing to receive events from the bag.
-    fn eject_events(&self, ejector: impl FnMut(Self::Mux));
+    fn eject_events(&self, ejector: impl FnMut(Self::Value));
 }
 
 unsafe impl<T: Bag, const N: usize> Bag for [T; N] {
@@ -144,17 +144,17 @@ unsafe impl<T: Bag, const N: usize> Bag for [T; N] {
     }
 }
 
-unsafe impl<T: BagMux, const N: usize> BagMux for [T; N] {
-    type Mux = (usize, T::Mux); // Include index to identify which bag the value came from
+unsafe impl<T: AsPort, const N: usize> AsPort for [T; N] {
+    type Value = (usize, T::Value); // Include index to identify which bag the value came from
 
-    fn inject_event(&mut self, (index, event): Self::Mux) -> Result<(), Self::Mux> {
+    fn inject_event(&mut self, (index, event): Self::Value) -> Result<(), Self::Value> {
         match self.get_mut(index) {
             Some(elem) => elem.inject_event(event).map_err(|err| (index, err)),
             None => Err((index, event)),
         }
     }
 
-    fn eject_events(&self, mut ejector: impl FnMut(Self::Mux)) {
+    fn eject_events(&self, mut ejector: impl FnMut(Self::Value)) {
         for (index, elem) in self.iter().enumerate() {
             elem.eject_events(|v| ejector((index, v)));
         }
@@ -204,12 +204,12 @@ impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T
 impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10);
 impl_bag_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10, 11 => T11);
 
-macro_rules! impl_bagmux_for_tuple {
+macro_rules! impl_asport_for_tuple {
     ($($idx:tt => $T:ident),+) => {
-        unsafe impl<$($T: BagMux),+> BagMux for ($($T,)+) {
-            type Mux = ($(Option<$T::Mux>,)+);
+        unsafe impl<$($T: AsPort),+> AsPort for ($($T,)+) {
+            type Value = ($(Option<$T::Value>,)+);
 
-            fn inject_event(&mut self, event: Self::Mux) -> Result<(), Self::Mux> {
+            fn inject_event(&mut self, event: Self::Value) -> Result<(), Self::Value> {
                 let mut event = event;
                 let mut had_error = false;
                 $(
@@ -223,10 +223,10 @@ macro_rules! impl_bagmux_for_tuple {
                 if had_error { Err(event) } else { Ok(()) }
             }
 
-            fn eject_events(&self, mut ejector: impl FnMut(Self::Mux)) {
+            fn eject_events(&self, mut ejector: impl FnMut(Self::Value)) {
                 $(
                     self.$idx.eject_events(|v| {
-                        let mut mux: Self::Mux = Default::default();
+                        let mut mux: Self::Value = Default::default();
                         mux.$idx = Some(v);
                         ejector(mux);
                     });
@@ -236,18 +236,18 @@ macro_rules! impl_bagmux_for_tuple {
     }
 }
 
-impl_bagmux_for_tuple!(0 => T0);
-impl_bagmux_for_tuple!(0 => T0, 1 => T1);
-impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2);
-impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3);
-impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4);
-impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5);
-impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6);
-impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7);
-impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8);
-impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9);
-impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10);
-impl_bagmux_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10, 11 => T11);
+impl_asport_for_tuple!(0 => T0);
+impl_asport_for_tuple!(0 => T0, 1 => T1);
+impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2);
+impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3);
+impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4);
+impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5);
+impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6);
+impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7);
+impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8);
+impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9);
+impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10);
+impl_asport_for_tuple!(0 => T0, 1 => T1, 2 => T2, 3 => T3, 4 => T4, 5 => T5, 6 => T6, 7 => T7, 8 => T8, 9 => T9, 10 => T10, 11 => T11);
 
 #[cfg(test)]
 mod tests {
@@ -393,7 +393,7 @@ mod tests {
     }
 
     #[test]
-    fn port_bagmux_impl_contract() {
+    fn port_asport_impl_contract() {
         let mut bag = <Port<u32, 2> as Bag>::build();
         assert!(bag.is_empty());
 
@@ -409,7 +409,7 @@ mod tests {
     }
 
     #[test]
-    fn array_bagmux_impl_contract() {
+    fn array_asport_impl_contract() {
         let mut bags = <[Port<u32, 2>; 3] as Bag>::build();
         assert!(bags.is_empty());
 
@@ -429,7 +429,7 @@ mod tests {
     }
 
     #[test]
-    fn tuple_bagmux_impl_2_elements() {
+    fn tuple_asport_impl_2_elements() {
         let mut bag = <(Port<u32, 1>, Port<bool, 1>) as Bag>::build();
         assert!(bag.is_empty());
 
@@ -453,7 +453,7 @@ mod tests {
     }
 
     #[test]
-    fn tuple_bagmux_impl_full_preserves_failed_positions() {
+    fn tuple_asport_impl_full_preserves_failed_positions() {
         let mut bag = <(Port<u32, 1>, Port<bool, 1>) as Bag>::build();
         bag.inject_event((Some(1u32), None)).unwrap();
         bag.inject_event((None, Some(true))).unwrap();
@@ -532,40 +532,40 @@ mod tests {
         assert_eq!(port.len(), 0);
     }
 
-    #[derive(crate::Bag, crate::BagMux)]
+    #[derive(crate::Bag, crate::AsPort)]
     struct InnerBag {
         a: Port<u32, 2>,
     }
 
-    #[derive(crate::Bag, crate::BagMux)]
+    #[derive(crate::Bag, crate::AsPort)]
     struct OuterBag {
         inner: InnerBag,
         b: Port<bool, 1>,
     }
 
     #[test]
-    fn nested_bagmux_impl() {
+    fn nested_asport_impl() {
         let mut outer = <OuterBag as Bag>::build();
         assert!(outer.is_empty());
 
-        let inner_event = _xdevs_no_std_inner_bag_bagmux::PortMux::A(42u32);
-        let outer_inner = _xdevs_no_std_outer_bag_bagmux::PortMux::Inner(inner_event);
+        let inner_event = _xdevs_no_std_inner_bag_asport::PortMux::A(42u32);
+        let outer_inner = _xdevs_no_std_outer_bag_asport::PortMux::Inner(inner_event);
         assert!(outer.inject_event(outer_inner).is_ok());
         assert!(!outer.is_empty());
 
         assert!(outer
-            .inject_event(_xdevs_no_std_outer_bag_bagmux::PortMux::B(true))
+            .inject_event(_xdevs_no_std_outer_bag_asport::PortMux::B(true))
             .is_ok());
 
         let mut got_a: heapless::Vec<u32, 4> = heapless::Vec::new();
         let mut got_b: heapless::Vec<bool, 4> = heapless::Vec::new();
         outer.eject_events(|ev| match ev {
-            _xdevs_no_std_outer_bag_bagmux::PortMux::Inner(inner) => match inner {
-                _xdevs_no_std_inner_bag_bagmux::PortMux::A(v) => {
+            _xdevs_no_std_outer_bag_asport::PortMux::Inner(inner) => match inner {
+                _xdevs_no_std_inner_bag_asport::PortMux::A(v) => {
                     let _ = got_a.push(v);
                 }
             },
-            _xdevs_no_std_outer_bag_bagmux::PortMux::B(v) => {
+            _xdevs_no_std_outer_bag_asport::PortMux::B(v) => {
                 let _ = got_b.push(v);
             }
         });

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -640,7 +640,7 @@ where
 #[cfg(test)]
 pub(crate) mod test_utils {
     use crate::{
-        port::Port, Atomic, AtomicKind, Component, ComponentsInput, ComponentsOutput, Coupled,
+        port::Port, Atomic, AtomicKind, Bag, Component, ComponentsInput, ComponentsOutput, Coupled,
         CoupledKind,
     };
 

--- a/src/simulation/coordinator.rs
+++ b/src/simulation/coordinator.rs
@@ -106,7 +106,7 @@ mod tests {
     use super::*;
     use crate::{
         component::coupled::PartialCoupled,
-        port::Port,
+        port::{Bag, Port},
         simulation::test_utils::{TestAtomic, TestCoupled},
     };
 

--- a/src/simulation/simulator.rs
+++ b/src/simulation/simulator.rs
@@ -103,7 +103,10 @@ unsafe impl<T: Atomic> AbstractSimulator for Simulator<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{port::Port, simulation::test_utils::TestAtomic};
+    use crate::{
+        port::{Bag, Port},
+        simulation::test_utils::TestAtomic,
+    };
 
     #[test]
     fn start_sets_timing() {


### PR DESCRIPTION
Remove AsPort and turn BagMux into a common interface for Port, arrays and tuple. This makes the RtEngine aplicable to all of the provided structs and collections.